### PR TITLE
Get service via Passage Facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,32 @@ return [
 ]
 ```
 
+#### Using the `Passage` facade
+If you wish not to use automatic routing of Passage and instead use the Passage services manuall in your controllers, you can use the `Passage` facade.
+```php
+// config/passage.php
+return [
+    'services' => [
+        'github' => 'https://api.github.com/',
+    ]
+]
+```
+
+and in your controller:
+```php
+// app/Http/Controllers/UserController.php
+
+use Morcen\Passage\Facades\Passage
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        $response = Passage::getService('github')->get('users/morcen');
+        return $response->json();
+    }
+}
+```
 
 ### Disabling `Passage`
 To disable `Passage` on a server/application level, set `PASSAGE_ENABLED` to `false` in your `.env` file:

--- a/src/Exceptions/MissingPassageService.php
+++ b/src/Exceptions/MissingPassageService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class MissingPassageService extends Exception
+{
+    //
+}

--- a/src/Facades/Passage.php
+++ b/src/Facades/Passage.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @see \Morcen\Passage\Passage
+ *
+ * @method static mixed getService(string $service)
  */
 class Passage extends Facade
 {

--- a/src/Passage.php
+++ b/src/Passage.php
@@ -2,6 +2,23 @@
 
 namespace Morcen\Passage;
 
+use App\Exceptions\MissingPassageService;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
 class Passage
 {
+    /**
+     * @param  string  $service
+     * @return PendingRequest
+     * @throws MissingPassageService
+     */
+    public function getService(string $service): PendingRequest
+    {
+        if (Http::hasMacro($service)) {
+            return Http::$service();
+        }
+
+        throw new MissingPassageService("The service \"{$service}\" is not available in your passage services.");
+    }
 }

--- a/src/Passage.php
+++ b/src/Passage.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Facades\Http;
 class Passage
 {
     /**
-     * @param  string  $service
-     * @return PendingRequest
      * @throws MissingPassageService
      */
     public function getService(string $service): PendingRequest


### PR DESCRIPTION
This PR will add a wrapper to getting the Http macro of a Passage service via `Passage::getService()` method, which accepts the name of the service as the parameter