### PR TITLE
feat: add security layer with auth traits, allowed hosts guard, and header stripping

### DIFF
--- a/config/passage.php
+++ b/config/passage.php
@@ -46,4 +46,53 @@ return [
         */
         'connect_timeout' => env('PASSAGE_CONNECT_TIMEOUT', 10),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passage Security
+    |--------------------------------------------------------------------------
+    |
+    | These options control the security behaviour of the proxy layer.
+    |
+    */
+
+    'security' => [
+        /*
+        | When true, only hosts listed in allowed_hosts may be used as
+        | upstream targets. Passage will refuse to proxy to any other host.
+        | Recommended for production deployments.
+        */
+        'enforce_allowed_hosts' => env('PASSAGE_ENFORCE_ALLOWED_HOSTS', false),
+
+        /*
+        | List of allowed upstream hostnames. Only checked when
+        | enforce_allowed_hosts is true.
+        |
+        | Example: ['api.github.com', 'api.stripe.com']
+        */
+        'allowed_hosts' => [],
+
+        /*
+        | Headers stripped from the inbound client request before it
+        | reaches the handler. This prevents client credentials from
+        | leaking to upstream services.
+        |
+        | Handlers may re-add these with service-level credentials via
+        | getRequest() or by using the HasBearerAuth / HasApiKeyAuth traits.
+        |
+        | To allow a header through on a specific handler, implement
+        | AcceptsClientHeaders (Phase 4) or remove it from this list globally.
+        */
+        'strip_client_headers' => ['cookie', 'authorization', 'proxy-authorization'],
+
+        /*
+        | Hop-by-hop headers are always stripped and cannot be configured.
+        | These are transport-level headers that must not be forwarded by
+        | any proxy (RFC 7230).
+        */
+        'hop_by_hop_headers' => [
+            'host', 'connection', 'transfer-encoding', 'upgrade',
+            'keep-alive', 'te', 'trailer', 'proxy-authenticate',
+        ],
+    ],
 ];

--- a/src/Concerns/HasApiKeyAuth.php
+++ b/src/Concerns/HasApiKeyAuth.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Morcen\Passage\Concerns;
+
+use Illuminate\Http\Request;
+
+trait HasApiKeyAuth
+{
+    /**
+     * Inject an API key as a request header.
+     *
+     * Example:
+     *   return $this->withApiKey($request, config('services.stripe.key'));
+     *   return $this->withApiKey($request, config('services.service.key'), 'X-Api-Key');
+     */
+    protected function withApiKey(
+        Request $request,
+        string $key,
+        string $headerName = 'X-API-Key'
+    ): Request {
+        $request->headers->set($headerName, $key);
+
+        return $request;
+    }
+
+    /**
+     * Inject an API key as a query parameter.
+     *
+     * Example:
+     *   return $this->withApiKeyQuery($request, config('services.maps.key'));
+     *   return $this->withApiKeyQuery($request, config('services.maps.key'), 'key');
+     */
+    protected function withApiKeyQuery(
+        Request $request,
+        string $key,
+        string $paramName = 'api_key'
+    ): Request {
+        $request->query->set($paramName, $key);
+
+        return $request;
+    }
+}

--- a/src/Concerns/HasBearerAuth.php
+++ b/src/Concerns/HasBearerAuth.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Morcen\Passage\Concerns;
+
+use Illuminate\Http\Request;
+
+trait HasBearerAuth
+{
+    /**
+     * Inject a Bearer token into the outbound request.
+     *
+     * Call this from getRequest() to authenticate against the upstream service.
+     *
+     * Example:
+     *   return $this->withBearerToken($request, config('services.github.token'));
+     */
+    protected function withBearerToken(Request $request, string $token): Request
+    {
+        $request->headers->set('Authorization', 'Bearer '.$token);
+
+        return $request;
+    }
+}

--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Morcen\Passage\Concerns;
+
+use Illuminate\Http\Request;
+
+trait HasHmacAuth
+{
+    /**
+     * Sign the outbound request with an HMAC signature.
+     *
+     * The signature is computed over: timestamp + "." + request body.
+     * Two headers are added to the request:
+     *   X-Timestamp  — Unix timestamp used in the signature (replay protection)
+     *   X-Signature  — HMAC hex digest: hash_hmac($algorithm, "$timestamp.$body", $secret)
+     *
+     * The header names and algorithm are configurable.
+     *
+     * Example:
+     *   return $this->withHmacSignature($request, config('services.partner.secret'));
+     */
+    protected function withHmacSignature(
+        Request $request,
+        string $secret,
+        string $algorithm = 'sha256',
+        string $timestampHeader = 'X-Timestamp',
+        string $signatureHeader = 'X-Signature'
+    ): Request {
+        $timestamp = (string) time();
+        $body = $request->getContent();
+        $payload = $timestamp.'.'.$body;
+        $signature = hash_hmac($algorithm, $payload, $secret);
+
+        $request->headers->set($timestampHeader, $timestamp);
+        $request->headers->set($signatureHeader, $signature);
+
+        return $request;
+    }
+}

--- a/src/Exceptions/DisallowedProxyTargetException.php
+++ b/src/Exceptions/DisallowedProxyTargetException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Morcen\Passage\Exceptions;
+
+use Exception;
+
+class DisallowedProxyTargetException extends Exception
+{
+    //
+}

--- a/src/Exceptions/PassageRequestAbortedException.php
+++ b/src/Exceptions/PassageRequestAbortedException.php
@@ -8,7 +8,7 @@ class PassageRequestAbortedException extends Exception
 {
     /**
      * @param  string  $message  Error message returned to the caller.
-     * @param  int     $status   HTTP status code for the response (default 400).
+     * @param  int  $status  HTTP status code for the response (default 400).
      */
     public function __construct(string $message = 'Request aborted.', int $status = 400)
     {

--- a/src/Exceptions/PassageRequestAbortedException.php
+++ b/src/Exceptions/PassageRequestAbortedException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Morcen\Passage\Exceptions;
+
+use Exception;
+
+class PassageRequestAbortedException extends Exception
+{
+    /**
+     * @param  string  $message  Error message returned to the caller.
+     * @param  int     $status   HTTP status code for the response (default 400).
+     */
+    public function __construct(string $message = 'Request aborted.', int $status = 400)
+    {
+        parent::__construct($message, $status);
+    }
+
+    public function getHttpStatus(): int
+    {
+        return $this->getCode();
+    }
+}

--- a/src/Guards/AllowedHostsGuard.php
+++ b/src/Guards/AllowedHostsGuard.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Morcen\Passage\Guards;
+
+use Morcen\Passage\Exceptions\DisallowedProxyTargetException;
+
+class AllowedHostsGuard
+{
+    /**
+     * Assert that the given base URI is permitted as an upstream proxy target.
+     *
+     * When enforce_allowed_hosts is false (default), the check is a no-op and
+     * all upstream hosts are permitted. Enable it in production to prevent
+     * open-proxy misconfigurations.
+     *
+     * @throws DisallowedProxyTargetException
+     */
+    public function check(string $baseUri): void
+    {
+        if (! config('passage.security.enforce_allowed_hosts', false)) {
+            return;
+        }
+
+        $host = parse_url($baseUri, PHP_URL_HOST);
+
+        if ($host === false || $host === null) {
+            throw new DisallowedProxyTargetException(
+                "Could not determine upstream host from base_uri [{$baseUri}]."
+            );
+        }
+
+        $allowedHosts = config('passage.security.allowed_hosts', []);
+
+        if (! in_array($host, $allowedHosts, strict: true)) {
+            throw new DisallowedProxyTargetException(
+                "Upstream host [{$host}] is not in the passage allowed_hosts list."
+            );
+        }
+    }
+}

--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -5,6 +5,8 @@ namespace Morcen\Passage\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Morcen\Passage\Exceptions\InvalidBaseUriException;
+use Morcen\Passage\Exceptions\PassageRequestAbortedException;
+use Morcen\Passage\Guards\AllowedHostsGuard;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
@@ -12,14 +14,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PassageController extends Controller
 {
-    // Stripped from the inbound client request before the handler sees it.
-    // Prevents client credentials from leaking to upstream services.
-    // Phase 2 will make this list configurable via config('passage.security.strip_client_headers').
-    private const SENSITIVE_CLIENT_HEADERS = ['cookie', 'authorization', 'proxy-authorization'];
-
     public function __construct(
         protected readonly PassageServiceInterface $passageService,
         protected readonly PassageResponseBuilder $responseBuilder,
+        protected readonly AllowedHostsGuard $allowedHostsGuard,
     ) {}
 
     public function handle(Request $request): Response
@@ -41,15 +39,22 @@ class PassageController extends Controller
             throw new InvalidBaseUriException("Passage handler [{$handler}] must return a 'base_uri' from getOptions().");
         }
 
+        $this->allowedHostsGuard->check($options['base_uri']);
+
         $pendingRequest = Http::withOptions($options);
 
         // Strip sensitive client headers before the handler processes the request.
         // The handler may re-add these with service-level credentials (e.g. via HasBearerAuth).
-        foreach (self::SENSITIVE_CLIENT_HEADERS as $header) {
+        foreach (config('passage.security.strip_client_headers', []) as $header) {
             $request->headers->remove($header);
         }
 
-        $request = $handlerInstance->getRequest($request);
+        try {
+            $request = $handlerInstance->getRequest($request);
+        } catch (PassageRequestAbortedException $e) {
+            return response()->json(['error' => $e->getMessage()], $e->getHttpStatus());
+        }
+
         $upstream = $this->passageService->callService($request, $pendingRequest, $path);
         $upstream = $handlerInstance->getResponse($request, $upstream);
 

--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -7,8 +7,8 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class PassageResponseBuilder
 {
-    // Hop-by-hop headers that must not be forwarded from upstream to client.
-    private const HOP_BY_HOP_HEADERS = [
+    // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
+    private const HOP_BY_HOP_FALLBACK = [
         'connection', 'transfer-encoding', 'upgrade',
         'keep-alive', 'te', 'trailer', 'proxy-authenticate',
         'proxy-authorization',
@@ -40,10 +40,11 @@ class PassageResponseBuilder
 
     private function resolveResponseHeaders(Response $upstream): array
     {
+        $hopByHop = config('passage.security.hop_by_hop_headers', self::HOP_BY_HOP_FALLBACK);
         $headers = [];
 
         foreach ($upstream->headers() as $name => $values) {
-            if (in_array(strtolower($name), self::HOP_BY_HOP_HEADERS, strict: true)) {
+            if (in_array(strtolower($name), $hopByHop, strict: true)) {
                 continue;
             }
             $headers[$name] = is_array($values) ? implode(', ', $values) : $values;

--- a/src/PassageHandler.php
+++ b/src/PassageHandler.php
@@ -32,7 +32,7 @@ use Morcen\Passage\Concerns\HasHmacAuth;
  */
 abstract class PassageHandler implements PassageControllerInterface
 {
-    use HasBearerAuth, HasApiKeyAuth, HasHmacAuth;
+    use HasApiKeyAuth, HasBearerAuth, HasHmacAuth;
 
     public function getRequest(Request $request): Request
     {

--- a/src/PassageHandler.php
+++ b/src/PassageHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Morcen\Passage;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Request;
+use Morcen\Passage\Concerns\HasApiKeyAuth;
+use Morcen\Passage\Concerns\HasBearerAuth;
+use Morcen\Passage\Concerns\HasHmacAuth;
+
+/**
+ * Optional abstract base class for Passage handlers.
+ *
+ * Extend this instead of implementing PassageControllerInterface directly
+ * to get no-op defaults for all three interface methods plus the auth helper
+ * traits (HasBearerAuth, HasApiKeyAuth, HasHmacAuth) available out of the box.
+ *
+ * You only need to override the methods relevant to your handler:
+ *
+ *   class GithubHandler extends PassageHandler
+ *   {
+ *       public function getRequest(Request $request): Request
+ *       {
+ *           return $this->withBearerToken($request, config('services.github.token'));
+ *       }
+ *
+ *       public function getOptions(): array
+ *       {
+ *           return ['base_uri' => 'https://api.github.com/'];
+ *       }
+ *   }
+ */
+abstract class PassageHandler implements PassageControllerInterface
+{
+    use HasBearerAuth, HasApiKeyAuth, HasHmacAuth;
+
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return [];
+    }
+}

--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -8,8 +8,8 @@ use Illuminate\Http\Request;
 
 class PassageService implements PassageServiceInterface
 {
-    // Always stripped — hop-by-hop headers must never be forwarded by a proxy.
-    private const HOP_BY_HOP_HEADERS = [
+    // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
+    private const HOP_BY_HOP_FALLBACK = [
         'host', 'connection', 'transfer-encoding', 'upgrade',
         'keep-alive', 'te', 'trailer', 'proxy-authenticate',
     ];
@@ -66,10 +66,11 @@ class PassageService implements PassageServiceInterface
 
     private function resolveForwardedHeaders(Request $request): array
     {
+        $hopByHop = config('passage.security.hop_by_hop_headers', self::HOP_BY_HOP_FALLBACK);
         $headers = [];
 
         foreach ($request->headers->all() as $name => $values) {
-            if (in_array(strtolower($name), self::HOP_BY_HOP_HEADERS, strict: true)) {
+            if (in_array(strtolower($name), $hopByHop, strict: true)) {
                 continue;
             }
             $headers[$name] = implode(', ', $values);

--- a/tests/Unit/AllowedHostsGuardTest.php
+++ b/tests/Unit/AllowedHostsGuardTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Morcen\Passage\Exceptions\DisallowedProxyTargetException;
+use Morcen\Passage\Guards\AllowedHostsGuard;
+
+beforeEach(function () {
+    $this->guard = new AllowedHostsGuard;
+});
+
+describe('AllowedHostsGuard', function () {
+    describe('when enforce_allowed_hosts is false (default)', function () {
+        it('permits any host without checking the allowlist', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => false,
+                'passage.security.allowed_hosts' => [],
+            ]);
+
+            // Should not throw for any host
+            expect(fn () => $this->guard->check('https://api.example.com/'))->not->toThrow(DisallowedProxyTargetException::class);
+            expect(fn () => $this->guard->check('https://evil.example.com/'))->not->toThrow(DisallowedProxyTargetException::class);
+        });
+    });
+
+    describe('when enforce_allowed_hosts is true', function () {
+        beforeEach(function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => true,
+                'passage.security.allowed_hosts' => ['api.github.com', 'api.stripe.com'],
+            ]);
+        });
+
+        it('permits hosts in the allowlist', function () {
+            expect(fn () => $this->guard->check('https://api.github.com/v3/'))->not->toThrow(DisallowedProxyTargetException::class);
+            expect(fn () => $this->guard->check('https://api.stripe.com/'))->not->toThrow(DisallowedProxyTargetException::class);
+        });
+
+        it('throws for hosts not in the allowlist', function () {
+            expect(fn () => $this->guard->check('https://api.evil.com/'))
+                ->toThrow(DisallowedProxyTargetException::class);
+        });
+
+        it('throws for a subdomain not explicitly listed', function () {
+            expect(fn () => $this->guard->check('https://v3.api.github.com/'))
+                ->toThrow(DisallowedProxyTargetException::class);
+        });
+
+        it('throws when base_uri has no parseable host', function () {
+            expect(fn () => $this->guard->check('not-a-url'))
+                ->toThrow(DisallowedProxyTargetException::class);
+        });
+    });
+});

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -2,9 +2,7 @@
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
-use Morcen\Passage\Concerns\HasApiKeyAuth;
-use Morcen\Passage\Concerns\HasBearerAuth;
-use Morcen\Passage\Concerns\HasHmacAuth;
+use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\PassageHandler;
 
 // Concrete handler using PassageHandler base class
@@ -194,7 +192,8 @@ describe('HasHmacAuth', function () {
 
 describe('PassageHandler base class', function () {
     it('provides no-op defaults for all three interface methods', function () {
-        $handler = new class extends PassageHandler {
+        $handler = new class extends PassageHandler
+        {
             public function getOptions(): array
             {
                 return ['base_uri' => 'https://api.example.com/'];
@@ -208,13 +207,14 @@ describe('PassageHandler base class', function () {
     });
 
     it('implements PassageControllerInterface', function () {
-        $handler = new class extends PassageHandler {
+        $handler = new class extends PassageHandler
+        {
             public function getOptions(): array
             {
                 return ['base_uri' => 'https://api.example.com/'];
             }
         };
 
-        expect($handler)->toBeInstanceOf(\Morcen\Passage\PassageControllerInterface::class);
+        expect($handler)->toBeInstanceOf(PassageControllerInterface::class);
     });
 });

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Request;
+use Morcen\Passage\Concerns\HasApiKeyAuth;
+use Morcen\Passage\Concerns\HasBearerAuth;
+use Morcen\Passage\Concerns\HasHmacAuth;
+use Morcen\Passage\PassageHandler;
+
+// Concrete handler using PassageHandler base class
+class BearerAuthHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withBearerToken($request, 'test-service-token');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/'];
+    }
+}
+
+class ApiKeyHeaderHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withApiKey($request, 'my-api-key');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/'];
+    }
+}
+
+class ApiKeyQueryHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withApiKeyQuery($request, 'my-api-key', 'key');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://maps.example.com/'];
+    }
+}
+
+class HmacHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withHmacSignature($request, 'super-secret');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://partner.example.com/'];
+    }
+}
+
+describe('HasBearerAuth', function () {
+    it('sets Authorization header with Bearer prefix', function () {
+        $handler = new BearerAuthHandler;
+        $request = Request::create('/test', 'GET');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->header('Authorization'))->toBe('Bearer test-service-token');
+    });
+});
+
+// Fixture: custom header name
+class ApiKeyCustomHeaderHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withApiKey($request, 'my-api-key', 'X-Auth-Token');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/'];
+    }
+}
+
+// Fixture: custom query param name
+class ApiKeyCustomParamHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withApiKeyQuery($request, 'my-api-key', 'access_key');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/'];
+    }
+}
+
+describe('HasApiKeyAuth', function () {
+    it('sets the default X-API-Key header', function () {
+        $handler = new ApiKeyHeaderHandler;
+        $request = Request::create('/test', 'GET');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->header('X-API-Key'))->toBe('my-api-key');
+    });
+
+    it('supports a custom header name', function () {
+        $handler = new ApiKeyCustomHeaderHandler;
+        $request = Request::create('/test', 'GET');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->header('X-Auth-Token'))->toBe('my-api-key');
+    });
+
+    it('injects API key as a query parameter', function () {
+        $handler = new ApiKeyQueryHandler;
+        $request = Request::create('/test', 'GET');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->query('key'))->toBe('my-api-key');
+    });
+
+    it('supports a custom query param name', function () {
+        $handler = new ApiKeyCustomParamHandler;
+        $request = Request::create('/test', 'GET');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->query('access_key'))->toBe('my-api-key');
+    });
+});
+
+// Fixture: custom HMAC headers and algorithm
+class HmacCustomHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withHmacSignature($request, 'super-secret', 'sha512', 'X-Req-Time', 'X-Req-Sig');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://partner.example.com/'];
+    }
+}
+
+describe('HasHmacAuth', function () {
+    it('adds X-Timestamp and X-Signature headers', function () {
+        $handler = new HmacHandler;
+        $request = Request::create('/test', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '{"id":1}');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->header('X-Timestamp'))->not->toBeEmpty();
+        expect($result->header('X-Signature'))->not->toBeEmpty();
+    });
+
+    it('produces a verifiable HMAC signature', function () {
+        $secret = 'my-secret';
+        $body = '{"event":"test"}';
+        $handler = new HmacHandler; // uses 'super-secret', so re-verify with its secret
+        $request = Request::create('/test', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], $body);
+
+        $result = $handler->getRequest($request);
+
+        $timestamp = $result->header('X-Timestamp');
+        $signature = $result->header('X-Signature');
+        $expected = hash_hmac('sha256', $timestamp.'.'.$body, 'super-secret');
+
+        expect($signature)->toBe($expected);
+    });
+
+    it('supports custom header names and algorithm', function () {
+        $handler = new HmacCustomHandler;
+        $request = Request::create('/test', 'POST');
+
+        $result = $handler->getRequest($request);
+
+        expect($result->header('X-Req-Time'))->not->toBeEmpty();
+        expect($result->header('X-Req-Sig'))->not->toBeEmpty();
+
+        $timestamp = $result->header('X-Req-Time');
+        $expected = hash_hmac('sha512', $timestamp.'.', 'super-secret');
+        expect($result->header('X-Req-Sig'))->toBe($expected);
+    });
+});
+
+describe('PassageHandler base class', function () {
+    it('provides no-op defaults for all three interface methods', function () {
+        $handler = new class extends PassageHandler {
+            public function getOptions(): array
+            {
+                return ['base_uri' => 'https://api.example.com/'];
+            }
+        };
+        $request = Request::create('/test', 'GET');
+        $response = Mockery::mock(Response::class);
+
+        expect($handler->getRequest($request))->toBe($request);
+        expect($handler->getResponse($request, $response))->toBe($response);
+    });
+
+    it('implements PassageControllerInterface', function () {
+        $handler = new class extends PassageHandler {
+            public function getOptions(): array
+            {
+                return ['base_uri' => 'https://api.example.com/'];
+            }
+        };
+
+        expect($handler)->toBeInstanceOf(\Morcen\Passage\PassageControllerInterface::class);
+    });
+});

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Http;
 use Morcen\Passage\Exceptions\InvalidBaseUriException;
+use Morcen\Passage\Exceptions\PassageRequestAbortedException;
+use Morcen\Passage\Guards\AllowedHostsGuard;
 use Morcen\Passage\Http\Controllers\PassageController;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
@@ -116,7 +118,11 @@ class TestNoBaseUriPassageController implements PassageControllerInterface
 beforeEach(function () {
     $this->mockPassageService = Mockery::mock(PassageServiceInterface::class);
     $this->app->instance(PassageServiceInterface::class, $this->mockPassageService);
-    $this->controller = new PassageController($this->mockPassageService, new PassageResponseBuilder);
+    $this->controller = new PassageController(
+        $this->mockPassageService,
+        new PassageResponseBuilder,
+        new AllowedHostsGuard,
+    );
 });
 
 /**
@@ -291,5 +297,63 @@ describe('PassageController', function () {
         $this->mockPassageService->shouldReceive('callService')->once()->andReturn($mockResponse);
 
         $this->controller->handle($request);
+    });
+
+    describe('configurable sensitive header stripping', function () {
+        it('strips headers listed in config strip_client_headers', function () {
+            config(['passage.security.strip_client_headers' => ['x-internal-secret']]);
+
+            $request = Request::create('/github/users', 'GET');
+            $request->headers->set('X-Internal-Secret', 'do-not-forward');
+            $request->headers->set('X-Safe-Header', 'forward-me');
+
+            $route = (new Route(['GET'], '/github/{path?}', []))
+                ->defaults('_passage_handler', TestPassageController::class);
+            $route->bind($request);
+            $request->setRouteResolver(fn () => $route);
+
+            Http::shouldReceive('withOptions')->once()->andReturn(Mockery::mock(PendingRequest::class));
+
+            $this->mockPassageService->shouldReceive('callService')
+                ->withArgs(function (Request $req) {
+                    return $req->header('X-Internal-Secret') === null
+                        && $req->header('X-Safe-Header') === 'forward-me';
+                })
+                ->once()
+                ->andReturn(jsonUpstreamResponse([]));
+
+            $this->controller->handle($request);
+        });
+    });
+
+    describe('PassageRequestAbortedException', function () {
+        it('returns a formatted JSON error when handler throws PassageRequestAbortedException', function () {
+            // Inline handler that aborts
+            $abortingHandler = new class implements PassageControllerInterface {
+                public function getRequest(Request $request): Request
+                {
+                    throw new PassageRequestAbortedException('Access denied.', 403);
+                }
+                public function getResponse(Request $request, Response $response): Response { return $response; }
+                public function getOptions(): array { return ['base_uri' => 'https://api.example.com/']; }
+            };
+
+            // Register the anonymous class name dynamically
+            $handlerClass = get_class($abortingHandler);
+
+            $request = Request::create('/proxy/resource', 'GET');
+            $route = (new Route(['GET'], '/proxy/{path?}', []))
+                ->defaults('_passage_handler', $handlerClass);
+            $route->bind($request);
+            $request->setRouteResolver(fn () => $route);
+
+            Http::shouldReceive('withOptions')->once()->andReturn(Mockery::mock(PendingRequest::class));
+            $this->mockPassageService->shouldReceive('callService')->never();
+
+            $response = $this->controller->handle($request);
+
+            expect($response->getStatusCode())->toBe(403);
+            expect($response->getData(true))->toBe(['error' => 'Access denied.']);
+        });
     });
 });

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -329,13 +329,22 @@ describe('PassageController', function () {
     describe('PassageRequestAbortedException', function () {
         it('returns a formatted JSON error when handler throws PassageRequestAbortedException', function () {
             // Inline handler that aborts
-            $abortingHandler = new class implements PassageControllerInterface {
+            $abortingHandler = new class implements PassageControllerInterface
+            {
                 public function getRequest(Request $request): Request
                 {
                     throw new PassageRequestAbortedException('Access denied.', 403);
                 }
-                public function getResponse(Request $request, Response $response): Response { return $response; }
-                public function getOptions(): array { return ['base_uri' => 'https://api.example.com/']; }
+
+                public function getResponse(Request $request, Response $response): Response
+                {
+                    return $response;
+                }
+
+                public function getOptions(): array
+                {
+                    return ['base_uri' => 'https://api.example.com/'];
+                }
             };
 
             // Register the anonymous class name dynamically


### PR DESCRIPTION
## Summary

Introduces a comprehensive security layer for the Passage proxy, including authentication helper traits, an allowed-hosts guard to prevent open-proxy misconfigurations, configurable header stripping, and a new `PassageHandler` abstract base class for streamlined handler development.

## Changes

### Auth Traits
- **`HasBearerAuth`** — injects a Bearer token into the outbound `Authorization` header
- **`HasApiKeyAuth`** — injects an API key as a header (`X-API-Key`) or query parameter (`api_key`)
- **`HasHmacAuth`** — signs the outbound request with an HMAC signature (timestamp + body) for webhook-style auth

### Allowed Hosts Guard
- New `AllowedHostsGuard` validates the upstream `base_uri` against a configurable allowlist
- Enabled via `PASSAGE_ENFORCE_ALLOWED_HOSTS=true`; recommended for production to prevent proxying to arbitrary hosts
- Throws `DisallowedProxyTargetException` when a host is not permitted

### Configurable Header Stripping
- Sensitive client headers (`cookie`, `authorization`, `proxy-authorization`) and hop-by-hop headers are now driven by `config('passage.security')` instead of hardcoded constants
- Fallback constants retained for early-bootstrap scenarios

### `PassageHandler` Abstract Base Class
- Provides no-op defaults for `getRequest()`, `getResponse()`, and `getOptions()`
- Bundles all three auth traits so handlers get helpers out of the box
- Handlers only need to override the methods relevant to their use case

### `PassageRequestAbortedException`
- New exception that handlers can throw from `getRequest()` to abort proxying and return a JSON error response with a configurable HTTP status code

### Tests
- Added tests for `AllowedHostsGuard` (enforcement on/off, missing host, allowed/disallowed hosts)
- Added tests for `HasBearerAuth`, `HasApiKeyAuth`, and `HasHmacAuth` traits
- Added tests for `PassageRequestAbortedException` handling in the controller
- Added tests for configurable header stripping and hop-by-hop header forwarding