### PR TITLE
feat: add v3.0 features - route facade, response caching, events, retries, and error handling

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,113 +1,105 @@
 # Upgrade Guide
 
+## Upgrading from v2.x to v3.0
+
+v3.0 is a breaking release. The config-based service array and the `Route::passage()` macro have been removed in favour of explicit route registration using the `Passage` facade.
+
+### Breaking Changes
+
+#### 1. `config/passage.php` — `services` array removed
+
+The `services` array is no longer read by Passage. Remove it from your config file.
+
+**Before:**
+```php
+// config/passage.php
+'services' => [
+    'github' => App\Http\Controllers\Passages\GithubPassageController::class,
+],
+```
+
+**After:** delete the `services` key entirely. Routes are registered directly (see below).
+
+#### 2. `Route::passage()` macro removed
+
+The `Route::passage()` macro no longer exists.
+
+**Before:**
+```php
+Route::passage('github');
+```
+
+**After:** register routes explicitly using the `Passage` facade:
+```php
+use Morcen\Passage\Facades\Passage;
+
+Passage::get('github/{path?}', GithubPassageController::class);
+Passage::post('github/{path?}', GithubPassageController::class);
+// or cover all methods at once:
+Passage::any('github/{path?}', GithubPassageController::class);
+```
+
+Passage routes return a standard Laravel `Route` instance, so you can chain `.name()`, `.middleware()`, and other route methods as usual.
+
+#### 3. Array-based handler configuration removed
+
+Handlers must be dedicated classes implementing `PassageControllerInterface`. Anonymous arrays or closures are no longer accepted.
+
+#### 4. Handler `getOptions()` must return `base_uri`
+
+Every handler must return at minimum a `base_uri` from `getOptions()`. Passage will throw `InvalidBaseUriException` at request time if it is missing.
+
+```php
+public function getOptions(): array
+{
+    return [
+        'base_uri' => 'https://api.example.com/',
+    ];
+}
+```
+
+### Migration Steps
+
+1. Remove the `services` array from `config/passage.php`.
+2. Replace every `Route::passage('service-name')` call with `Passage::get/post/any(...)`.
+3. Ensure each handler class implements `PassageControllerInterface` and returns a `base_uri` from `getOptions()`.
+4. Run `php artisan passage:list` to confirm your routes are registered correctly.
+5. Run your test suite: `php artisan test`.
+
+### Generating New Handlers
+
+```bash
+php artisan passage:controller YourServiceName
+```
+
+The generated stub includes all three required interface methods with inline guidance.
+
+---
+
 ## Upgrading from v1.x to v2.0
 
 ### Requirements Changes
 
-**Before (v1.x):**
-- PHP 8.1+
-- Laravel 8.x+
-
-**After (v2.0):**
-- PHP 8.2+ (8.3+ recommended)
-- Laravel 11.x+
+| | v1.x | v2.0 |
+|---|---|---|
+| PHP | 8.1+ | 8.2+ |
+| Laravel | 8.x+ | 11.x+ |
 
 ### Breaking Changes
 
-#### 1. Minimum PHP Version
-The minimum PHP version has been upgraded from **8.1** to **8.2**. While we recommend PHP 8.3+ for the best experience, PHP 8.2 is the minimum requirement.
-
-#### 2. Minimum Laravel Version
-The minimum Laravel version has been upgraded from **8.x** to **11.x**. This provides access to the latest Laravel features and security updates.
-
-#### 3. Updated Dependencies
-All development dependencies have been updated to their latest versions compatible with Laravel 11:
-
-- `spatie/laravel-package-tools`: ^1.16.0 (from ^1.14.0)
-- `illuminate/contracts`: ^11.0 (from ^10.0)
-- `pestphp/pest`: ^2.35.0 (from ^2.0)
-- And many more...
-
-### What's Improved
-
-#### 1. Modern PHP Features
-- Enhanced readonly properties for better immutability
-- Better type safety with modern PHP features
-- Performance improvements from PHP 8.2/8.3 features
-
-#### 2. Comprehensive Test Suite
-- 31 tests with 103 assertions
-- All core functionality tested
-- Removed flaky integration tests with Guzzle dependencies
-
-#### 3. Better Developer Experience
-- Updated PHPStan configuration for better static analysis
-- Latest Laravel Pint for code formatting
-- Modern Pest testing framework
-- Enhanced GitHub Actions workflows with matrix testing
-- Security audit automation
-- Automated dependency management
+- Minimum PHP raised to **8.2**.
+- Minimum Laravel raised to **11.x**.
+- All dev dependencies updated to Laravel 11-compatible versions.
 
 ### Migration Steps
 
-#### 1. Check System Requirements
-Ensure your system meets the new requirements:
+1. Upgrade PHP to 8.2+.
+2. Upgrade Laravel to 11.x (`composer update laravel/framework`).
+3. Update Passage: `composer update morcen/passage`.
+4. Run your tests: `php artisan test`.
 
-```bash
-php -v  # Should show PHP 8.2+
-```
+No API or configuration changes were required between v1 and v2.
 
-#### 2. Update Your Laravel Project
-If your Laravel application is not yet on Laravel 11, upgrade it first:
+---
 
-```bash
-composer update laravel/framework
-```
-
-#### 3. Update Passage
-Update the package to v2.0:
-
-```bash
-composer update morcen/passage
-```
-
-#### 4. Run Tests
-Ensure your application still works correctly:
-
-```bash
-php artisan test
-```
-
-### Configuration Changes
-
-No configuration changes are required. All existing `config/passage.php` configurations remain compatible.
-
-### API Changes
-
-There are **no breaking API changes**. All existing:
-- Service configurations
-- Custom controllers implementing `PassageControllerInterface`  
-- Route macros
-- Facade usage
-
-...will continue to work exactly as before.
-
-### Deprecations
-
-None. This is a clean upgrade focused on modernizing the underlying platform requirements.
-
-### Rollback Plan
-
-If you need to rollback for any reason:
-
-```bash
-composer require "morcen/passage:^1.0"
-```
-
-Note that this will also require downgrading your PHP/Laravel versions to meet the v1.x requirements.
-
-### Support
-
-- v1.x will receive security updates for 6 months after v2.0 release
-- v2.0+ receives full feature and security support
-- For issues, please file them on [GitHub](https://github.com/morcen/passage/issues)
+For issues, please file them on [GitHub](https://github.com/morcen/passage/issues).

--- a/config/passage.php
+++ b/config/passage.php
@@ -95,4 +95,37 @@ return [
             'keep-alive', 'te', 'trailer', 'proxy-authenticate',
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passage Response Cache
+    |--------------------------------------------------------------------------
+    |
+    | GET and HEAD responses can be cached per-route by returning
+    | passage_cache_ttl (seconds) from a handler's getOptions().
+    |
+    | Uses Laravel's Cache facade with the store configured below.
+    | null = use the application's default cache store.
+    |
+    */
+
+    'cache' => [
+        'store' => env('PASSAGE_CACHE_STORE', null),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passage Events
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Passage fires Laravel events around each proxy call:
+    |   PassageRequestSending, PassageResponseReceived, PassageRequestFailed
+    |
+    | Register PassageEventSubscriber in your EventServiceProvider to log them.
+    |
+    */
+
+    'events' => [
+        'enabled' => env('PASSAGE_EVENTS', true),
+    ],
 ];

--- a/src/Concerns/HasResilienceOptions.php
+++ b/src/Concerns/HasResilienceOptions.php
@@ -10,10 +10,10 @@ trait HasResilienceOptions
      * Passage will extract these keys before passing options to Guzzle and
      * apply ->retry() on the PendingRequest automatically.
      *
-     * @param  int           $times   Maximum number of retry attempts.
-     * @param  int           $sleepMs Milliseconds to wait between retries.
-     * @param  callable|null $when    Optional callable(Response $response, Throwable $e): bool.
-     *                                When null, retries on connection errors and 5xx responses.
+     * @param  int  $times  Maximum number of retry attempts.
+     * @param  int  $sleepMs  Milliseconds to wait between retries.
+     * @param  callable|null  $when  Optional callable(Response $response, Throwable $e): bool.
+     *                               When null, retries on connection errors and 5xx responses.
      *
      * Example:
      *   public function getOptions(): array
@@ -27,9 +27,9 @@ trait HasResilienceOptions
     protected function withRetry(int $times, int $sleepMs = 100, ?callable $when = null): array
     {
         return array_filter([
-            'passage_retry_times'    => $times,
+            'passage_retry_times' => $times,
             'passage_retry_sleep_ms' => $sleepMs,
-            'passage_retry_when'     => $when,
+            'passage_retry_when' => $when,
         ], fn ($v) => $v !== null);
     }
 }

--- a/src/Concerns/HasResilienceOptions.php
+++ b/src/Concerns/HasResilienceOptions.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Morcen\Passage\Concerns;
+
+trait HasResilienceOptions
+{
+    /**
+     * Return retry configuration to merge into getOptions().
+     *
+     * Passage will extract these keys before passing options to Guzzle and
+     * apply ->retry() on the PendingRequest automatically.
+     *
+     * @param  int           $times   Maximum number of retry attempts.
+     * @param  int           $sleepMs Milliseconds to wait between retries.
+     * @param  callable|null $when    Optional callable(Response $response, Throwable $e): bool.
+     *                                When null, retries on connection errors and 5xx responses.
+     *
+     * Example:
+     *   public function getOptions(): array
+     *   {
+     *       return array_merge(
+     *           ['base_uri' => 'https://api.example.com/'],
+     *           $this->withRetry(3, 200)
+     *       );
+     *   }
+     */
+    protected function withRetry(int $times, int $sleepMs = 100, ?callable $when = null): array
+    {
+        return array_filter([
+            'passage_retry_times'    => $times,
+            'passage_retry_sleep_ms' => $sleepMs,
+            'passage_retry_when'     => $when,
+        ], fn ($v) => $v !== null);
+    }
+}

--- a/src/Events/PassageRequestFailed.php
+++ b/src/Events/PassageRequestFailed.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Morcen\Passage\Events;
+
+use Illuminate\Http\Request;
+use Throwable;
+
+class PassageRequestFailed
+{
+    /**
+     * @param  Request    $request     The transformed request (may be pre-abort state).
+     * @param  string     $handler     Fully-qualified handler class name.
+     * @param  Throwable  $exception   The transport-level exception that caused the failure.
+     * @param  float      $durationMs  Duration from request start to failure in milliseconds.
+     */
+    public function __construct(
+        public readonly Request $request,
+        public readonly string $handler,
+        public readonly Throwable $exception,
+        public readonly float $durationMs,
+    ) {}
+}

--- a/src/Events/PassageRequestFailed.php
+++ b/src/Events/PassageRequestFailed.php
@@ -8,10 +8,10 @@ use Throwable;
 class PassageRequestFailed
 {
     /**
-     * @param  Request    $request     The transformed request (may be pre-abort state).
-     * @param  string     $handler     Fully-qualified handler class name.
-     * @param  Throwable  $exception   The transport-level exception that caused the failure.
-     * @param  float      $durationMs  Duration from request start to failure in milliseconds.
+     * @param  Request  $request  The transformed request (may be pre-abort state).
+     * @param  string  $handler  Fully-qualified handler class name.
+     * @param  Throwable  $exception  The transport-level exception that caused the failure.
+     * @param  float  $durationMs  Duration from request start to failure in milliseconds.
      */
     public function __construct(
         public readonly Request $request,

--- a/src/Events/PassageRequestSending.php
+++ b/src/Events/PassageRequestSending.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Morcen\Passage\Events;
+
+use Illuminate\Http\Request;
+
+class PassageRequestSending
+{
+    /**
+     * @param  Request  $request      The transformed request (after getRequest() ran).
+     * @param  string   $handler      Fully-qualified handler class name.
+     * @param  string   $upstreamUri  Full upstream URI (base_uri + path).
+     * @param  float    $startedAt    microtime(true) at the start of the proxy call.
+     */
+    public function __construct(
+        public readonly Request $request,
+        public readonly string $handler,
+        public readonly string $upstreamUri,
+        public readonly float $startedAt,
+    ) {}
+}

--- a/src/Events/PassageRequestSending.php
+++ b/src/Events/PassageRequestSending.php
@@ -7,10 +7,10 @@ use Illuminate\Http\Request;
 class PassageRequestSending
 {
     /**
-     * @param  Request  $request      The transformed request (after getRequest() ran).
-     * @param  string   $handler      Fully-qualified handler class name.
-     * @param  string   $upstreamUri  Full upstream URI (base_uri + path).
-     * @param  float    $startedAt    microtime(true) at the start of the proxy call.
+     * @param  Request  $request  The transformed request (after getRequest() ran).
+     * @param  string  $handler  Fully-qualified handler class name.
+     * @param  string  $upstreamUri  Full upstream URI (base_uri + path).
+     * @param  float  $startedAt  microtime(true) at the start of the proxy call.
      */
     public function __construct(
         public readonly Request $request,

--- a/src/Events/PassageResponseReceived.php
+++ b/src/Events/PassageResponseReceived.php
@@ -8,11 +8,11 @@ use Illuminate\Http\Request;
 class PassageResponseReceived
 {
     /**
-     * @param  Request   $request     The transformed request.
-     * @param  Response  $response    The upstream response (after getResponse() ran).
-     * @param  string    $handler     Fully-qualified handler class name.
-     * @param  float     $durationMs  Total proxy call duration in milliseconds.
-     * @param  bool      $cached      Whether the response was served from cache.
+     * @param  Request  $request  The transformed request.
+     * @param  Response  $response  The upstream response (after getResponse() ran).
+     * @param  string  $handler  Fully-qualified handler class name.
+     * @param  float  $durationMs  Total proxy call duration in milliseconds.
+     * @param  bool  $cached  Whether the response was served from cache.
      */
     public function __construct(
         public readonly Request $request,

--- a/src/Events/PassageResponseReceived.php
+++ b/src/Events/PassageResponseReceived.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Morcen\Passage\Events;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Request;
+
+class PassageResponseReceived
+{
+    /**
+     * @param  Request   $request     The transformed request.
+     * @param  Response  $response    The upstream response (after getResponse() ran).
+     * @param  string    $handler     Fully-qualified handler class name.
+     * @param  float     $durationMs  Total proxy call duration in milliseconds.
+     * @param  bool      $cached      Whether the response was served from cache.
+     */
+    public function __construct(
+        public readonly Request $request,
+        public readonly Response $response,
+        public readonly string $handler,
+        public readonly float $durationMs,
+        public readonly bool $cached,
+    ) {}
+}

--- a/src/Exceptions/PassageUpstreamException.php
+++ b/src/Exceptions/PassageUpstreamException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Morcen\Passage\Exceptions;
+
+use Exception;
+
+class PassageUpstreamException extends Exception
+{
+    //
+}

--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -2,22 +2,41 @@
 
 namespace Morcen\Passage\Http\Controllers;
 
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Morcen\Passage\Events\PassageRequestFailed;
+use Morcen\Passage\Events\PassageRequestSending;
+use Morcen\Passage\Events\PassageResponseReceived;
 use Morcen\Passage\Exceptions\InvalidBaseUriException;
 use Morcen\Passage\Exceptions\PassageRequestAbortedException;
 use Morcen\Passage\Guards\AllowedHostsGuard;
+use Morcen\Passage\Http\PassageCacheManager;
+use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class PassageController extends Controller
 {
+    // Reserved option keys consumed by Passage before passing options to Guzzle.
+    private const PASSAGE_KEYS = [
+        'passage_retry_times',
+        'passage_retry_sleep_ms',
+        'passage_retry_when',
+        'passage_cache_ttl',
+        'passage_streaming',
+    ];
+
     public function __construct(
         protected readonly PassageServiceInterface $passageService,
         protected readonly PassageResponseBuilder $responseBuilder,
         protected readonly AllowedHostsGuard $allowedHostsGuard,
+        protected readonly PassageCacheManager $cacheManager,
+        protected readonly PassageErrorHandler $errorHandler,
     ) {}
 
     public function handle(Request $request): Response
@@ -33,18 +52,28 @@ class PassageController extends Controller
         }
 
         $handlerInstance = new $handler;
-        $options = array_merge(config('passage.options', []), $handlerInstance->getOptions());
+        $mergedOptions = array_merge(config('passage.options', []), $handlerInstance->getOptions());
 
-        if (empty($options['base_uri'])) {
+        if (empty($mergedOptions['base_uri'])) {
             throw new InvalidBaseUriException("Passage handler [{$handler}] must return a 'base_uri' from getOptions().");
         }
 
-        $this->allowedHostsGuard->check($options['base_uri']);
+        $this->allowedHostsGuard->check($mergedOptions['base_uri']);
 
-        $pendingRequest = Http::withOptions($options);
+        // Extract Passage reserved keys before passing options to Guzzle.
+        [$passageOptions, $guzzleOptions] = $this->extractPassageOptions($mergedOptions);
+
+        $pendingRequest = Http::withOptions($guzzleOptions);
+
+        if (isset($passageOptions['passage_retry_times'])) {
+            $pendingRequest = $pendingRequest->retry(
+                $passageOptions['passage_retry_times'],
+                $passageOptions['passage_retry_sleep_ms'] ?? 100,
+                $passageOptions['passage_retry_when'] ?? null,
+            );
+        }
 
         // Strip sensitive client headers before the handler processes the request.
-        // The handler may re-add these with service-level credentials (e.g. via HasBearerAuth).
         foreach (config('passage.security.strip_client_headers', []) as $header) {
             $request->headers->remove($header);
         }
@@ -55,9 +84,76 @@ class PassageController extends Controller
             return response()->json(['error' => $e->getMessage()], $e->getHttpStatus());
         }
 
-        $upstream = $this->passageService->callService($request, $pendingRequest, $path);
+        // Check cache before making the upstream call.
+        $cacheTtl = $passageOptions['passage_cache_ttl'] ?? null;
+        $fullUrl = rtrim($mergedOptions['base_uri'], '/').'/'.$path;
+
+        if ($cacheTtl !== null) {
+            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $guzzleOptions);
+            if ($cached !== null) {
+                $upstream = $handlerInstance->getResponse($request, $cached);
+                $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, 0.0, true));
+
+                return $this->responseBuilder->build($upstream);
+            }
+        }
+
+        $startedAt = microtime(true);
+        $this->fireEvent(new PassageRequestSending($request, $handler, $fullUrl, $startedAt));
+
+        try {
+            $upstream = $this->passageService->callService($request, $pendingRequest, $path);
+        } catch (ConnectionException|Throwable $e) {
+            $durationMs = (microtime(true) - $startedAt) * 1000;
+            $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));
+
+            return $this->errorHandler->handle($e);
+        }
+
+        $durationMs = (microtime(true) - $startedAt) * 1000;
+
+        if ($cacheTtl !== null) {
+            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $upstream);
+        }
+
+        // Streaming: skip getResponse() hook and return directly.
+        if (! empty($passageOptions['passage_streaming'])) {
+            $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, $durationMs, false));
+
+            return $this->responseBuilder->buildStreamedResponse($upstream);
+        }
+
         $upstream = $handlerInstance->getResponse($request, $upstream);
+        $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, $durationMs, false));
 
         return $this->responseBuilder->build($upstream);
+    }
+
+    /**
+     * Split merged options into [passage_*, guzzle_options].
+     *
+     * @return array{0: array<string,mixed>, 1: array<string,mixed>}
+     */
+    private function extractPassageOptions(array $options): array
+    {
+        $passage = [];
+        $guzzle = [];
+
+        foreach ($options as $key => $value) {
+            if (in_array($key, self::PASSAGE_KEYS, strict: true)) {
+                $passage[$key] = $value;
+            } else {
+                $guzzle[$key] = $value;
+            }
+        }
+
+        return [$passage, $guzzle];
+    }
+
+    private function fireEvent(object $event): void
+    {
+        if (config('passage.events.enabled', true)) {
+            Event::dispatch($event);
+        }
     }
 }

--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Morcen\Passage\Http;
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Cache;
+
+class PassageCacheManager
+{
+    /**
+     * Attempt to return a cached response.
+     * Returns null on a cache miss, or if caching is not applicable.
+     */
+    public function get(string $method, string $fullUrl, int $ttl, array $options): ?Response
+    {
+        if (! $this->isCacheable($method)) {
+            return null;
+        }
+
+        $cached = Cache::store($this->store())->get($this->key($method, $fullUrl, $options));
+
+        if ($cached === null) {
+            return null;
+        }
+
+        return $this->reconstruct($cached);
+    }
+
+    /**
+     * Store an upstream response in the cache.
+     * No-op for non-cacheable methods.
+     */
+    public function put(string $method, string $fullUrl, int $ttl, array $options, Response $response): void
+    {
+        if (! $this->isCacheable($method)) {
+            return;
+        }
+
+        Cache::store($this->store())->put(
+            $this->key($method, $fullUrl, $options),
+            [
+                'status'  => $response->status(),
+                'headers' => $response->headers(),
+                'body'    => $response->body(),
+            ],
+            $ttl
+        );
+    }
+
+    private function isCacheable(string $method): bool
+    {
+        return in_array(strtoupper($method), ['GET', 'HEAD'], strict: true);
+    }
+
+    private function key(string $method, string $fullUrl, array $options): string
+    {
+        return 'passage:'.md5($method.$fullUrl.serialize($options));
+    }
+
+    private function store(): ?string
+    {
+        return config('passage.cache.store');
+    }
+
+    private function reconstruct(array $cached): Response
+    {
+        $psr7 = new Psr7Response(
+            $cached['status'],
+            $cached['headers'],
+            $cached['body']
+        );
+
+        return new Response($psr7);
+    }
+}

--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -40,9 +40,9 @@ class PassageCacheManager
         Cache::store($this->store())->put(
             $this->key($method, $fullUrl, $options),
             [
-                'status'  => $response->status(),
+                'status' => $response->status(),
                 'headers' => $response->headers(),
-                'body'    => $response->body(),
+                'body' => $response->body(),
             ],
             $ttl
         );

--- a/src/Http/PassageErrorHandler.php
+++ b/src/Http/PassageErrorHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Morcen\Passage\Http;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class PassageErrorHandler
+{
+    /**
+     * Map a transport-level exception to an appropriate HTTP error response.
+     *
+     * Upstream 4xx/5xx responses are NOT exceptions and must NOT be passed here —
+     * they travel through PassageResponseBuilder as normal responses.
+     * Only connection-level failures (timeouts, DNS, TLS, redirect loops) reach this handler.
+     */
+    public function handle(Throwable $e): JsonResponse
+    {
+        $status = $this->resolveStatus($e);
+
+        return response()->json(
+            ['error' => $this->resolveMessage($e, $status)],
+            $status
+        );
+    }
+
+    private function resolveStatus(Throwable $e): int
+    {
+        // Laravel wraps Guzzle connect/timeout errors in ConnectionException.
+        if ($e instanceof ConnectionException) {
+            // Distinguish timeout from other connection failures via the wrapped Guzzle cause.
+            $cause = $e->getPrevious();
+            if ($cause instanceof ConnectException) {
+                $context = $cause->getHandlerContext();
+                if (isset($context['errno']) && $context['errno'] === CURLE_OPERATION_TIMEDOUT) {
+                    return Response::HTTP_GATEWAY_TIMEOUT; // 504
+                }
+            }
+
+            return Response::HTTP_BAD_GATEWAY; // 502
+        }
+
+        if ($e instanceof TooManyRedirectsException) {
+            return Response::HTTP_BAD_GATEWAY; // 502
+        }
+
+        return Response::HTTP_INTERNAL_SERVER_ERROR; // 500
+    }
+
+    private function resolveMessage(Throwable $e, int $status): string
+    {
+        return match ($status) {
+            Response::HTTP_GATEWAY_TIMEOUT    => 'Upstream service timed out.',
+            Response::HTTP_BAD_GATEWAY        => 'Upstream service is unreachable.',
+            default                           => 'An unexpected error occurred.',
+        };
+    }
+}

--- a/src/Http/PassageErrorHandler.php
+++ b/src/Http/PassageErrorHandler.php
@@ -54,9 +54,9 @@ class PassageErrorHandler
     private function resolveMessage(Throwable $e, int $status): string
     {
         return match ($status) {
-            Response::HTTP_GATEWAY_TIMEOUT    => 'Upstream service timed out.',
-            Response::HTTP_BAD_GATEWAY        => 'Upstream service is unreachable.',
-            default                           => 'An unexpected error occurred.',
+            Response::HTTP_GATEWAY_TIMEOUT => 'Upstream service timed out.',
+            Response::HTTP_BAD_GATEWAY => 'Upstream service is unreachable.',
+            default => 'An unexpected error occurred.',
         };
     }
 }

--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -4,6 +4,7 @@ namespace Morcen\Passage\Http;
 
 use Illuminate\Http\Client\Response;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PassageResponseBuilder
 {
@@ -33,6 +34,35 @@ class PassageResponseBuilder
 
         foreach ($headers as $name => $value) {
             $response->header($name, $value);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Build a StreamedResponse, reading from the upstream PSR-7 body stream.
+     *
+     * Note: The getResponse() handler hook is NOT called for streamed responses —
+     * the body cannot be inspected before it is sent.
+     */
+    public function buildStreamedResponse(Response $upstream): StreamedResponse
+    {
+        $status = $upstream->status();
+        $headers = $this->resolveResponseHeaders($upstream);
+        $stream = $upstream->toPsrResponse()->getBody();
+
+        $response = new StreamedResponse(
+            function () use ($stream) {
+                while (! $stream->eof()) {
+                    echo $stream->read(4096);
+                    flush();
+                }
+            },
+            $status
+        );
+
+        foreach ($headers as $name => $value) {
+            $response->headers->set($name, $value);
         }
 
         return $response;

--- a/src/Listeners/PassageEventSubscriber.php
+++ b/src/Listeners/PassageEventSubscriber.php
@@ -33,26 +33,26 @@ class PassageEventSubscriber
     {
         Log::channel($this->channel())->debug('Passage: forwarding request', [
             'handler' => $event->handler,
-            'uri'     => $event->upstreamUri,
-            'method'  => $event->request->method(),
+            'uri' => $event->upstreamUri,
+            'method' => $event->request->method(),
         ]);
     }
 
     public function onResponseReceived(PassageResponseReceived $event): void
     {
         Log::channel($this->channel())->info('Passage: response received', [
-            'handler'     => $event->handler,
-            'status'      => $event->response->status(),
+            'handler' => $event->handler,
+            'status' => $event->response->status(),
             'duration_ms' => round($event->durationMs, 2),
-            'cached'      => $event->cached,
+            'cached' => $event->cached,
         ]);
     }
 
     public function onRequestFailed(PassageRequestFailed $event): void
     {
         Log::channel($this->channel())->error('Passage: request failed', [
-            'handler'     => $event->handler,
-            'error'       => $event->exception->getMessage(),
+            'handler' => $event->handler,
+            'error' => $event->exception->getMessage(),
             'duration_ms' => round($event->durationMs, 2),
         ]);
     }
@@ -60,9 +60,9 @@ class PassageEventSubscriber
     public function subscribe(Dispatcher $events): array
     {
         return [
-            PassageRequestSending::class   => 'onRequestSending',
+            PassageRequestSending::class => 'onRequestSending',
             PassageResponseReceived::class => 'onResponseReceived',
-            PassageRequestFailed::class    => 'onRequestFailed',
+            PassageRequestFailed::class => 'onRequestFailed',
         ];
     }
 

--- a/src/Listeners/PassageEventSubscriber.php
+++ b/src/Listeners/PassageEventSubscriber.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Morcen\Passage\Listeners;
+
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Log;
+use Morcen\Passage\Events\PassageRequestFailed;
+use Morcen\Passage\Events\PassageRequestSending;
+use Morcen\Passage\Events\PassageResponseReceived;
+
+/**
+ * Optional log subscriber for Passage events.
+ *
+ * Not registered automatically. To enable, add this to your EventServiceProvider:
+ *
+ *   protected $subscribe = [
+ *       \Morcen\Passage\Listeners\PassageEventSubscriber::class,
+ *   ];
+ *
+ * Logs to the 'passage' channel if configured, otherwise falls back to the
+ * default channel. Configure a dedicated channel in config/logging.php:
+ *
+ *   'passage' => [
+ *       'driver' => 'daily',
+ *       'path'   => storage_path('logs/passage.log'),
+ *       'level'  => 'debug',
+ *       'days'   => 7,
+ *   ],
+ */
+class PassageEventSubscriber
+{
+    public function onRequestSending(PassageRequestSending $event): void
+    {
+        Log::channel($this->channel())->debug('Passage: forwarding request', [
+            'handler' => $event->handler,
+            'uri'     => $event->upstreamUri,
+            'method'  => $event->request->method(),
+        ]);
+    }
+
+    public function onResponseReceived(PassageResponseReceived $event): void
+    {
+        Log::channel($this->channel())->info('Passage: response received', [
+            'handler'     => $event->handler,
+            'status'      => $event->response->status(),
+            'duration_ms' => round($event->durationMs, 2),
+            'cached'      => $event->cached,
+        ]);
+    }
+
+    public function onRequestFailed(PassageRequestFailed $event): void
+    {
+        Log::channel($this->channel())->error('Passage: request failed', [
+            'handler'     => $event->handler,
+            'error'       => $event->exception->getMessage(),
+            'duration_ms' => round($event->durationMs, 2),
+        ]);
+    }
+
+    public function subscribe(Dispatcher $events): array
+    {
+        return [
+            PassageRequestSending::class   => 'onRequestSending',
+            PassageResponseReceived::class => 'onResponseReceived',
+            PassageRequestFailed::class    => 'onRequestFailed',
+        ];
+    }
+
+    private function channel(): string
+    {
+        return 'passage';
+    }
+}

--- a/src/PassageHandler.php
+++ b/src/PassageHandler.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Morcen\Passage\Concerns\HasApiKeyAuth;
 use Morcen\Passage\Concerns\HasBearerAuth;
 use Morcen\Passage\Concerns\HasHmacAuth;
+use Morcen\Passage\Concerns\HasResilienceOptions;
 
 /**
  * Optional abstract base class for Passage handlers.
@@ -32,7 +33,7 @@ use Morcen\Passage\Concerns\HasHmacAuth;
  */
 abstract class PassageHandler implements PassageControllerInterface
 {
-    use HasApiKeyAuth, HasBearerAuth, HasHmacAuth;
+    use HasApiKeyAuth, HasBearerAuth, HasHmacAuth, HasResilienceOptions;
 
     public function getRequest(Request $request): Request
     {

--- a/src/PassageServiceProvider.php
+++ b/src/PassageServiceProvider.php
@@ -36,5 +36,8 @@ class PassageServiceProvider extends PackageServiceProvider
         if (isset($passage['enabled']) && $passage['enabled']) {
             $this->app->bind(PassageServiceInterface::class, PassageService::class);
         }
+
+        // PassageResponseBuilder, AllowedHostsGuard, PassageCacheManager, and
+        // PassageErrorHandler have no dependencies and are auto-resolved by the container.
     }
 }

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -9,6 +9,8 @@ use Morcen\Passage\Exceptions\InvalidBaseUriException;
 use Morcen\Passage\Exceptions\PassageRequestAbortedException;
 use Morcen\Passage\Guards\AllowedHostsGuard;
 use Morcen\Passage\Http\Controllers\PassageController;
+use Morcen\Passage\Http\PassageCacheManager;
+use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
@@ -122,6 +124,8 @@ beforeEach(function () {
         $this->mockPassageService,
         new PassageResponseBuilder,
         new AllowedHostsGuard,
+        new PassageCacheManager,
+        new PassageErrorHandler,
     );
 });
 

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
@@ -17,7 +18,6 @@ use Morcen\Passage\Http\Controllers\PassageController;
 use Morcen\Passage\Http\PassageCacheManager;
 use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
-use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\PassageHandler;
 use Morcen\Passage\Services\PassageServiceInterface;
 use Symfony\Component\HttpFoundation\Response as ResponseCode;
@@ -113,7 +113,8 @@ beforeEach(function () {
 
 describe('3.1 Retry ergonomics', function () {
     it('HasResilienceOptions::withRetry() produces the correct passage_* keys', function () {
-        $handler = new class {
+        $handler = new class
+        {
             use HasResilienceOptions;
 
             public function options(): array
@@ -125,7 +126,7 @@ describe('3.1 Retry ergonomics', function () {
         $opts = $handler->options();
 
         expect($opts)->toMatchArray([
-            'passage_retry_times'    => 3,
+            'passage_retry_times' => 3,
             'passage_retry_sleep_ms' => 200,
         ]);
     });
@@ -305,8 +306,8 @@ describe('3.4 Streaming', function () {
         $upstreamMock->shouldReceive('header')->with('Content-Type')->andReturn('text/event-stream');
 
         // toPsrResponse() → PSR-7 Response with a stream body
-        $stream = \GuzzleHttp\Psr7\Utils::streamFor('data: hello');
-        $psr7 = new \GuzzleHttp\Psr7\Response(200, [], $stream);
+        $stream = Utils::streamFor('data: hello');
+        $psr7 = new GuzzleHttp\Psr7\Response(200, [], $stream);
         $upstreamMock->shouldReceive('toPsrResponse')->andReturn($psr7);
 
         $this->mockService->shouldReceive('callService')->once()->andReturn($upstreamMock);

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -1,0 +1,384 @@
+<?php
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Morcen\Passage\Concerns\HasResilienceOptions;
+use Morcen\Passage\Events\PassageRequestFailed;
+use Morcen\Passage\Events\PassageRequestSending;
+use Morcen\Passage\Events\PassageResponseReceived;
+use Morcen\Passage\Guards\AllowedHostsGuard;
+use Morcen\Passage\Http\Controllers\PassageController;
+use Morcen\Passage\Http\PassageCacheManager;
+use Morcen\Passage\Http\PassageErrorHandler;
+use Morcen\Passage\Http\PassageResponseBuilder;
+use Morcen\Passage\PassageControllerInterface;
+use Morcen\Passage\PassageHandler;
+use Morcen\Passage\Services\PassageServiceInterface;
+use Symfony\Component\HttpFoundation\Response as ResponseCode;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+class RetryableHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return array_merge(
+            ['base_uri' => 'https://api.example.com/'],
+            $this->withRetry(3, 50)
+        );
+    }
+}
+
+class CachedHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/', 'passage_cache_ttl' => 60];
+    }
+}
+
+class StreamingHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/', 'passage_streaming' => true];
+    }
+}
+
+class BaseUriOnlyHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/'];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function phase3Controller(): PassageController
+{
+    return new PassageController(
+        app(PassageServiceInterface::class),
+        new PassageResponseBuilder,
+        new AllowedHostsGuard,
+        new PassageCacheManager,
+        new PassageErrorHandler,
+    );
+}
+
+function phase3Route(string $handlerClass, string $uri = '/proxy/items', string $pattern = '/proxy/{path?}'): Request
+{
+    $request = Request::create($uri, 'GET');
+    $route = (new Route(['GET'], $pattern, []))
+        ->defaults('_passage_handler', $handlerClass)
+        ->where('path', '.*');
+    $route->bind($request);
+    $request->setRouteResolver(fn () => $route);
+
+    return $request;
+}
+
+function jsonMockResponse(array $data = [], int $status = 200): Response
+{
+    $mock = Mockery::mock(Response::class);
+    $mock->shouldReceive('status')->andReturn($status);
+    $mock->shouldReceive('json')->andReturn($data);
+    $mock->shouldReceive('body')->andReturn(json_encode($data));
+    $mock->shouldReceive('header')->with('Content-Type')->andReturn('application/json');
+    $mock->shouldReceive('headers')->andReturn([]);
+
+    return $mock;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(function () {
+    $this->mockService = Mockery::mock(PassageServiceInterface::class);
+    $this->app->instance(PassageServiceInterface::class, $this->mockService);
+    config(['passage.events.enabled' => false]); // silence events by default in most tests
+});
+
+describe('3.1 Retry ergonomics', function () {
+    it('HasResilienceOptions::withRetry() produces the correct passage_* keys', function () {
+        $handler = new class {
+            use HasResilienceOptions;
+
+            public function options(): array
+            {
+                return $this->withRetry(3, 200);
+            }
+        };
+
+        $opts = $handler->options();
+
+        expect($opts)->toMatchArray([
+            'passage_retry_times'    => 3,
+            'passage_retry_sleep_ms' => 200,
+        ]);
+    });
+
+    it('passage_retry_* keys are stripped from guzzle options', function () {
+        $request = phase3Route(RetryableHandler::class);
+
+        Http::shouldReceive('withOptions')
+            ->withArgs(function (array $opts) {
+                return ! array_key_exists('passage_retry_times', $opts)
+                    && ! array_key_exists('passage_retry_sleep_ms', $opts)
+                    && $opts['base_uri'] === 'https://api.example.com/';
+            })
+            ->once()
+            ->andReturn(
+                Mockery::mock(PendingRequest::class)
+                    ->shouldReceive('retry')->once()->andReturnSelf()
+                    ->getMock()
+            );
+
+        $this->mockService->shouldReceive('callService')
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        phase3Controller()->handle($request);
+    });
+
+    it('withRetry() is available on PassageHandler subclasses', function () {
+        $handler = new RetryableHandler;
+        $opts = $handler->getOptions();
+
+        expect($opts)->toHaveKey('passage_retry_times', 3);
+        expect($opts)->toHaveKey('passage_retry_sleep_ms', 50);
+    });
+});
+
+describe('3.2 Response caching', function () {
+    it('caches a GET response and serves it on the second call without hitting upstream', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $request = phase3Route(CachedHandler::class);
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // First call: upstream is hit once
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse(['cached' => true]));
+
+        $controller = phase3Controller();
+        $first = $controller->handle($request);
+
+        // Second call: cache hit, upstream not called again
+        $second = phase3Controller()->handle(phase3Route(CachedHandler::class));
+
+        expect($first->getStatusCode())->toBe(200);
+        expect($second->getStatusCode())->toBe(200);
+    });
+
+    it('does not cache non-GET methods', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $request = Request::create('/proxy/items', 'POST');
+        $route = (new Route(['POST'], '/proxy/{path?}', []))
+            ->defaults('_passage_handler', CachedHandler::class)
+            ->where('path', '.*');
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // Both calls hit upstream
+        $this->mockService->shouldReceive('callService')
+            ->twice()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        phase3Controller()->handle($request);
+
+        $request2 = Request::create('/proxy/items', 'POST');
+        $route2 = (new Route(['POST'], '/proxy/{path?}', []))
+            ->defaults('_passage_handler', CachedHandler::class)
+            ->where('path', '.*');
+        $route2->bind($request2);
+        $request2->setRouteResolver(fn () => $route2);
+
+        phase3Controller()->handle($request2);
+    });
+
+    it('passage_cache_ttl is stripped from guzzle options', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $request = phase3Route(CachedHandler::class);
+
+        Http::shouldReceive('withOptions')
+            ->withArgs(fn (array $opts) => ! array_key_exists('passage_cache_ttl', $opts))
+            ->once()
+            ->andReturn(Mockery::mock(PendingRequest::class));
+
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse([]));
+
+        phase3Controller()->handle($request);
+    });
+});
+
+describe('3.3 Upstream error handling', function () {
+    it('returns 502 when upstream is unreachable', function () {
+        $request = phase3Route(BaseUriOnlyHandler::class);
+
+        Http::shouldReceive('withOptions')->once()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andThrow(new ConnectionException('Connection refused'));
+
+        $response = phase3Controller()->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_BAD_GATEWAY);
+        expect($response->getData(true))->toHaveKey('error');
+    });
+
+    it('returns 500 for unexpected exceptions', function () {
+        $request = phase3Route(BaseUriOnlyHandler::class);
+
+        Http::shouldReceive('withOptions')->once()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andThrow(new RuntimeException('Something went wrong'));
+
+        $response = phase3Controller()->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
+    });
+
+    it('passes through upstream 4xx and 5xx without treating them as errors', function () {
+        $request = phase3Route(BaseUriOnlyHandler::class);
+
+        Http::shouldReceive('withOptions')->once()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // 422 from upstream is a valid response — not a transport failure
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse(['message' => 'Unprocessable'], 422));
+
+        $response = phase3Controller()->handle($request);
+
+        expect($response->getStatusCode())->toBe(422);
+    });
+});
+
+describe('3.4 Streaming', function () {
+    it('passage_streaming is stripped from guzzle options', function () {
+        $request = phase3Route(StreamingHandler::class);
+
+        Http::shouldReceive('withOptions')
+            ->withArgs(fn (array $opts) => ! array_key_exists('passage_streaming', $opts))
+            ->once()
+            ->andReturn(Mockery::mock(PendingRequest::class));
+
+        $upstreamMock = Mockery::mock(Response::class);
+        $upstreamMock->shouldReceive('status')->andReturn(200);
+        $upstreamMock->shouldReceive('headers')->andReturn([]);
+        $upstreamMock->shouldReceive('header')->with('Content-Type')->andReturn('text/event-stream');
+
+        // toPsrResponse() → PSR-7 Response with a stream body
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor('data: hello');
+        $psr7 = new \GuzzleHttp\Psr7\Response(200, [], $stream);
+        $upstreamMock->shouldReceive('toPsrResponse')->andReturn($psr7);
+
+        $this->mockService->shouldReceive('callService')->once()->andReturn($upstreamMock);
+
+        $response = phase3Controller()->handle($request);
+
+        expect($response)->toBeInstanceOf(StreamedResponse::class);
+        expect($response->getStatusCode())->toBe(200);
+    });
+});
+
+describe('3.5 Events', function () {
+    beforeEach(function () {
+        config(['passage.events.enabled' => true]);
+    });
+
+    it('fires PassageRequestSending before the upstream call', function () {
+        Event::fake([PassageRequestSending::class, PassageResponseReceived::class]);
+
+        $request = phase3Route(BaseUriOnlyHandler::class);
+        Http::shouldReceive('withOptions')->once()->andReturn(Mockery::mock(PendingRequest::class));
+        $this->mockService->shouldReceive('callService')->once()->andReturn(jsonMockResponse());
+
+        phase3Controller()->handle($request);
+
+        Event::assertDispatched(PassageRequestSending::class, function ($e) {
+            return $e->handler === BaseUriOnlyHandler::class;
+        });
+    });
+
+    it('fires PassageResponseReceived after successful upstream call', function () {
+        Event::fake([PassageRequestSending::class, PassageResponseReceived::class]);
+
+        $request = phase3Route(BaseUriOnlyHandler::class);
+        Http::shouldReceive('withOptions')->once()->andReturn(Mockery::mock(PendingRequest::class));
+        $this->mockService->shouldReceive('callService')->once()->andReturn(jsonMockResponse(['ok' => true]));
+
+        phase3Controller()->handle($request);
+
+        Event::assertDispatched(PassageResponseReceived::class, function ($e) {
+            return $e->handler === BaseUriOnlyHandler::class
+                && $e->cached === false
+                && $e->durationMs >= 0;
+        });
+    });
+
+    it('fires PassageRequestFailed on transport errors', function () {
+        Event::fake([PassageRequestSending::class, PassageRequestFailed::class]);
+
+        $request = phase3Route(BaseUriOnlyHandler::class);
+        Http::shouldReceive('withOptions')->once()->andReturn(Mockery::mock(PendingRequest::class));
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andThrow(new ConnectionException('Timeout'));
+
+        phase3Controller()->handle($request);
+
+        Event::assertDispatched(PassageRequestFailed::class, function ($e) {
+            return $e->handler === BaseUriOnlyHandler::class;
+        });
+    });
+
+    it('does not fire events when passage.events.enabled is false', function () {
+        config(['passage.events.enabled' => false]);
+        Event::fake();
+
+        $request = phase3Route(BaseUriOnlyHandler::class);
+        Http::shouldReceive('withOptions')->once()->andReturn(Mockery::mock(PendingRequest::class));
+        $this->mockService->shouldReceive('callService')->once()->andReturn(jsonMockResponse());
+
+        phase3Controller()->handle($request);
+
+        Event::assertNothingDispatched();
+    });
+});


### PR DESCRIPTION
## Summary

This PR introduces Passage v3.0 with several major features and breaking changes. The config-based `services` array and `Route::passage()` macro have been replaced with an explicit `Passage` facade for route registration, giving developers full control over HTTP methods, paths, and standard Laravel route chaining.

## Breaking Changes

- **`services` config array removed** — routes are now registered via the `Passage` facade (`Passage::get()`, `Passage::post()`, `Passage::any()`, etc.)
- **`Route::passage()` macro removed** — replaced by the `Passage` facade
- **Array/closure-based handlers removed** — handlers must implement `PassageControllerInterface`
- **`base_uri` now required** — `getOptions()` must return a `base_uri` or `InvalidBaseUriException` is thrown

## New Features

### Route Facade
- New `Passage` facade for explicit route registration with full Laravel route API support (`.name()`, `.middleware()`, etc.)
- `Passage::get()`, `Passage::post()`, `Passage::any()`, and other HTTP method helpers

### Response Caching
- GET/HEAD responses can be cached per-route via `passage_cache_ttl` in handler options
- Configurable cache store via `PASSAGE_CACHE_STORE` env variable
- New `PassageCacheManager` handles cache key generation, storage, and retrieval

### Events
- `PassageRequestSending` — fired before the upstream request
- `PassageResponseReceived` — fired after a successful response (includes cache hit flag and duration)
- `PassageRequestFailed` — fired on transport-level failures (includes exception and duration)
- Togglable via `PASSAGE_EVENTS` env variable (enabled by default)

### Automatic Retries
- New `HasResilienceOptions` trait with `withRetry()` helper for retry configuration
- Supports configurable retry count, sleep interval, and conditional retry callable
- Reserved option keys (`passage_retry_times`, `passage_retry_sleep_ms`, `passage_retry_when`) are extracted before passing options to Guzzle

### Error Handling
- New `PassageErrorHandler` for centralized upstream error handling
- New `PassageUpstreamException` for transport-level failures

### Artisan Commands
- `passage:controller` generator updated with v3.0 stub including all interface methods
- `passage:list` command to verify registered routes

## Other Changes

- `PassageController` refactored to extract Passage-reserved option keys from Guzzle options
- Config file updated with `cache` and `events` sections
- `UPGRADE.md` rewritten with v2→v3 migration guide and condensed v1→v2 section