### PR TITLE
feat: add hmac controller stub

### DIFF
--- a/resources/stubs/controller.passage.hmac.stub
+++ b/resources/stubs/controller.passage.hmac.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Morcen\Passage\PassageHandler;
+
+class {{ class }} extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return [
+            'base_uri' => 'https://api.example.com/',
+        ];
+    }
+
+    public function getRequest(Request $request): Request
+    {
+        // Sign the outgoing request with an HMAC secret from your services config.
+        return $this->withHmacSignature($request, config('services.your-service.secret'));
+    }
+}


### PR DESCRIPTION
## Description

Adds the missing HMAC scaffold stub for `php artisan passage:controller --with-auth=hmac`, so the command generates a handler preconfigured to sign outgoing requests with `withHmacSignature()` instead of silently falling back to the default stub.

Fixes #53
