### PR TITLE
test: cover missing base_uri response

### DIFF
--- a/tests/Feature/PassageIntegrationTest.php
+++ b/tests/Feature/PassageIntegrationTest.php
@@ -62,6 +62,14 @@ class ValidatingHandler extends PassageHandler implements ValidatesInboundReques
     }
 }
 
+class NoBaseUriHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return [];
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -154,6 +162,14 @@ describe('Passage Integration Tests', function () {
     });
 
     describe('route registration', function () {
+        it('returns a server error when a handler omits base_uri', function () {
+            Passage::get('missing-base-uri/{path?}', NoBaseUriHandler::class);
+
+            $this->withExceptionHandling()
+                ->get('/missing-base-uri/resource')
+                ->assertStatus(500);
+        });
+
         it('returns 404 for a passage route with a missing handler', function () {
             Route::get('broken/{path?}', [
                 PassageController::class, 'handle',


### PR DESCRIPTION
## Description

Adds a feature-level integration test showing the actual HTTP response returned when a Passage handler omits `base_uri` from `getOptions()`.

## Notes

This machine does not have PHP/composer installed, so I could not run the Pest suite locally.

Fixes #54
