### PR TITLE
docs: document $when callback for conditional retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,18 @@ class PaymentsHandler extends PassageHandler
 php artisan passage:controller PaymentsHandler --with-retry
 ```
 
-`withRetry($times, $sleepMs, ?callable $when)` accepts an optional third argument — a callable that receives the exception and response and returns `true` if the request should be retried.
+`withRetry($times, $sleepMs, ?callable $when)` accepts an optional third argument — a callable that receives the exception and response and returns `true` if the request should be retried:
+
+```php
+$this->withRetry(
+    times: 3,
+    sleepMs: 200,
+    when: function (\Exception $e, \Illuminate\Http\Client\Response $response) {
+        // Only retry on connection errors, not on 4xx responses
+        return $e instanceof \Illuminate\Http\Client\ConnectionException;
+    }
+)
+```
 
 ### Upstream error handling
 


### PR DESCRIPTION
Add a short example to the Retry section of README.md showing the $when callback for conditional retries, such as skipping retries on 4xx responses. Fixes #56