### PR TITLE
docs: fix @param type hint for retry `$when` callback signature

### DIFF
--- a/src/Concerns/HasResilienceOptions.php
+++ b/src/Concerns/HasResilienceOptions.php
@@ -12,7 +12,7 @@ trait HasResilienceOptions
      *
      * @param  int  $times  Maximum number of retry attempts.
      * @param  int  $sleepMs  Milliseconds to wait between retries.
-     * @param  callable|null  $when  Optional callable(Response $response, Throwable $e): bool.
+     * @param  callable|null  $when  Optional callable(Throwable $exception, PendingRequest $request): bool.
      *                               When null, retries on connection errors and 5xx responses.
      *
      * Example:


### PR DESCRIPTION
## Summary
Fixes the `@param` docblock for the `$when` callback in the `HasResilienceOptions` trait to reflect the actual callback signature.

## Changes
- Updated the `$when` parameter type hint from `callable(Response $response, Throwable $e): bool` to `callable(Throwable $exception, PendingRequest $request): bool`, matching the actual method signature expected by the retry mechanism.

(as mentioned in https://github.com/morcen/passage/pull/57#pullrequestreview-4060233739)