### PR TITLE
fix: return structured JSON for invalid base URIs

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -58,11 +58,15 @@ class PassageController extends Controller
         $handlerInstance = $this->app->make($handler);
         $mergedOptions = array_merge(config('passage.options', []), $handlerInstance->getOptions());
 
-        if (empty($mergedOptions['base_uri'])) {
-            throw new InvalidBaseUriException("Passage handler [{$handler}] must return a 'base_uri' from getOptions().");
-        }
+        try {
+            if (empty($mergedOptions['base_uri'])) {
+                throw new InvalidBaseUriException("Passage handler [{$handler}] must return a 'base_uri' from getOptions().");
+            }
 
-        $this->allowedHostsGuard->check($mergedOptions['base_uri']);
+            $this->allowedHostsGuard->check($mergedOptions['base_uri']);
+        } catch (InvalidBaseUriException $e) {
+            return response()->json(['error' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
 
         // Extract Passage reserved keys before passing options to Guzzle.
         [$passageOptions, $guzzleOptions] = $this->extractPassageOptions($mergedOptions);

--- a/tests/Feature/PassageIntegrationTest.php
+++ b/tests/Feature/PassageIntegrationTest.php
@@ -186,12 +186,15 @@ describe('Passage Integration Tests', function () {
     });
 
     describe('route registration', function () {
-        it('returns a server error when a handler omits base_uri', function () {
+        it('returns a JSON server error when a handler omits base_uri', function () {
             Passage::get('missing-base-uri/{path?}', NoBaseUriHandler::class);
 
             $this->withExceptionHandling()
                 ->get('/missing-base-uri/resource')
-                ->assertStatus(500);
+                ->assertStatus(500)
+                ->assertJson([
+                    'error' => "Passage handler [NoBaseUriHandler] must return a 'base_uri' from getOptions().",
+                ]);
         });
 
         it('returns 404 for a passage route with a missing handler', function () {

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -182,7 +182,10 @@ describe('PassageController', function () {
 
         expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
         expect(json_decode($response->getContent(), true))->toBe([
-            'error' => "Passage handler [".TestNoBaseUriPassageController::class."] must return a 'base_uri' from getOptions().",
+            'error' => sprintf(
+                'Passage handler [%s] must return a \'base_uri\' from getOptions().',
+                TestNoBaseUriPassageController::class
+            ),
         ]);
     });
 

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -5,7 +5,6 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Http;
-use Morcen\Passage\Exceptions\InvalidBaseUriException;
 use Morcen\Passage\Exceptions\PassageRequestAbortedException;
 use Morcen\Passage\Guards\AllowedHostsGuard;
 use Morcen\Passage\Http\Controllers\PassageController;
@@ -170,7 +169,7 @@ describe('PassageController', function () {
         expect($response->getStatusCode())->toBe(ResponseCode::HTTP_NOT_FOUND);
     });
 
-    it('throws InvalidBaseUriException when handler returns no base_uri', function () {
+    it('returns a JSON server error when handler returns no base_uri', function () {
         $request = Request::create('/no-base-uri/test', 'GET');
         $route = (new Route(['GET'], '/no-base-uri/{path?}', []))
             ->defaults('_passage_handler', TestNoBaseUriPassageController::class);
@@ -179,8 +178,12 @@ describe('PassageController', function () {
 
         Http::shouldReceive('withOptions')->never();
 
-        expect(fn () => $this->controller->handle($request))
-            ->toThrow(InvalidBaseUriException::class);
+        $response = $this->controller->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
+        expect(json_decode($response->getContent(), true))->toBe([
+            'error' => "Passage handler [".TestNoBaseUriPassageController::class."] must return a 'base_uri' from getOptions().",
+        ]);
     });
 
     it('proxies a basic GET request and returns JSON response', function () {


### PR DESCRIPTION
## Summary
- catch InvalidBaseUriException in PassageController::handle() and return a JSON 500 error
- cover both missing ase_uri values and other invalid base URI failures raised before the upstream call
- update the feature and unit tests to assert the structured JSON error response

Closes #69.

## Testing
- not run (php and composer are not installed in this environment)