### PR TITLE
docs: add usage example to PassageControllerInterface

### DIFF
--- a/src/PassageControllerInterface.php
+++ b/src/PassageControllerInterface.php
@@ -5,6 +5,27 @@ namespace Morcen\Passage;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 
+/**
+ * Core contract for Passage handlers.
+ *
+ * Implementations define how inbound requests are transformed before they are
+ * forwarded upstream, how upstream responses are transformed before returning
+ * to the client, and which upstream options should be used for the route.
+ *
+ * In most cases you should extend PassageHandler instead of implementing this
+ * interface directly, since PassageHandler provides no-op defaults for all
+ * three methods and includes the built-in auth and resilience helpers.
+ *
+ * Example:
+ *
+ *   class GithubHandler extends PassageHandler
+ *   {
+ *       public function getOptions(): array
+ *       {
+ *           return ['base_uri' => 'https://api.github.com/'];
+ *       }
+ *   }
+ */
 interface PassageControllerInterface
 {
     /**


### PR DESCRIPTION
## Summary
- add a class-level docblock to PassageControllerInterface
- explain how the three methods fit together for Passage handlers
- include a minimal handler example and point readers to PassageHandler as the recommended base class

Closes #64.

## Testing
- not run (documentation-only change)