### PR TITLE
fix: make passage:list resilient to broken handlers

### DIFF
--- a/src/Commands/PassageListCommand.php
+++ b/src/Commands/PassageListCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 use Morcen\Passage\Http\Controllers\PassageController;
 use Morcen\Passage\PassageControllerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Throwable;
 
 #[AsCommand(name: 'passage:list')]
 class PassageListCommand extends Command
@@ -56,8 +57,12 @@ class PassageListCommand extends Command
             return $handler;
         }
 
-        $instance = new $handler;
-        $options = $instance->getOptions();
+        try {
+            $instance = new $handler;
+            $options = $instance->getOptions();
+        } catch (Throwable) {
+            return $handler.' (could not resolve target)';
+        }
 
         if (isset($options['base_uri'])) {
             return $options['base_uri'].' ('.$handler.')';

--- a/tests/Unit/PassageListCommandTest.php
+++ b/tests/Unit/PassageListCommandTest.php
@@ -23,6 +23,24 @@ class ListCommandTestPassageController implements PassageControllerInterface
     }
 }
 
+class ThrowingListCommandPassageController implements PassageControllerInterface
+{
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        throw new RuntimeException('boom');
+    }
+}
+
 describe('PassageListCommand', function () {
     it('warns when passage is disabled', function () {
         config()->set('passage.enabled', false);
@@ -61,6 +79,23 @@ describe('PassageListCommand', function () {
 
         $this->artisan('passage:list')
             ->expectsOutputToContain('github/{path?}')
+            ->assertExitCode(0);
+    });
+
+    it('continues listing routes when resolving a handler target throws', function () {
+        config()->set('passage.enabled', true);
+
+        Passage::get('broken-target/{path?}', ThrowingListCommandPassageController::class);
+
+        $this->artisan('passage:list')
+            ->expectsTable(
+                ['Method', 'URI', 'Target'],
+                [[
+                    'GET|HEAD',
+                    'broken-target/{path?}',
+                    ThrowingListCommandPassageController::class.' (could not resolve target)',
+                ]]
+            )
             ->assertExitCode(0);
     });
 });


### PR DESCRIPTION
## Summary
- catch handler instantiation and getOptions() failures in PassageListCommand::resolveTarget()
- fall back to a readable target string instead of crashing the command
- add a regression test for a handler whose getOptions() throws

Closes #65.

## Testing
- not run (php and composer are not installed in this environment)