### PR TITLE
 feature: add HasValidationHelpers trait

### DIFF
--- a/src/Concerns/HasValidationHelpers.php
+++ b/src/Concerns/HasValidationHelpers.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Morcen\Passage\Concerns;
+
+trait HasValidationHelpers
+{
+    /**
+     * Required integer ID (>= 1).
+     *
+     * Example:
+     *   'product_id' => $this->requiredId()
+     *   // ['required', 'integer', 'min:1']
+     */
+    protected function requiredId(): array
+    {
+        return ['required', 'integer', 'min:1'];
+    }
+
+    /**
+     * Required RFC-compliant email address.
+     *
+     * Example:
+     *   'email' => $this->requiredEmail()
+     *   // ['required', 'email:rfc']
+     */
+    protected function requiredEmail(): array
+    {
+        return ['required', 'email:rfc'];
+    }
+
+    /**
+     * Required string with an optional max length.
+     *
+     * Example:
+     *   'name' => $this->requiredString()       // ['required', 'string']
+     *   'name' => $this->requiredString(255)     // ['required', 'string', 'max:255']
+     */
+    protected function requiredString(?int $max = null): array
+    {
+        $rules = ['required', 'string'];
+
+        if ($max !== null) {
+            $rules[] = "max:{$max}";
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Optional (nullable) string with an optional max length.
+     *
+     * Example:
+     *   'note' => $this->optionalString()       // ['nullable', 'string']
+     *   'note' => $this->optionalString(500)     // ['nullable', 'string', 'max:500']
+     */
+    protected function optionalString(?int $max = null): array
+    {
+        $rules = ['nullable', 'string'];
+
+        if ($max !== null) {
+            $rules[] = "max:{$max}";
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Required positive integer (>= 1).
+     *
+     * Example:
+     *   'quantity' => $this->requiredPositiveInt()
+     *   // ['required', 'integer', 'min:1']
+     */
+    protected function requiredPositiveInt(): array
+    {
+        return ['required', 'integer', 'min:1'];
+    }
+
+    /**
+     * Required valid URL.
+     *
+     * Example:
+     *   'callback_url' => $this->requiredUrl()
+     *   // ['required', 'url']
+     */
+    protected function requiredUrl(): array
+    {
+        return ['required', 'url'];
+    }
+
+    /**
+     * Required value from a set of allowed values.
+     *
+     * Example:
+     *   'status' => $this->requiredIn('active', 'inactive')
+     *   // ['required', 'in:active,inactive']
+     */
+    protected function requiredIn(string ...$values): array
+    {
+        return ['required', 'in:'.implode(',', $values)];
+    }
+
+    /**
+     * Optional (nullable) value from a set of allowed values.
+     *
+     * Example:
+     *   'priority' => $this->optionalIn('low', 'medium', 'high')
+     *   // ['nullable', 'in:low,medium,high']
+     */
+    protected function optionalIn(string ...$values): array
+    {
+        return ['nullable', 'in:'.implode(',', $values)];
+    }
+
+    /**
+     * Required numeric value (integer or float).
+     *
+     * Example:
+     *   'amount' => $this->requiredNumeric()
+     *   // ['required', 'numeric']
+     */
+    protected function requiredNumeric(): array
+    {
+        return ['required', 'numeric'];
+    }
+}

--- a/src/PassageHandler.php
+++ b/src/PassageHandler.php
@@ -8,6 +8,7 @@ use Morcen\Passage\Concerns\HasApiKeyAuth;
 use Morcen\Passage\Concerns\HasBearerAuth;
 use Morcen\Passage\Concerns\HasHmacAuth;
 use Morcen\Passage\Concerns\HasResilienceOptions;
+use Morcen\Passage\Concerns\HasValidationHelpers;
 
 /**
  * Optional abstract base class for Passage handlers.
@@ -33,7 +34,7 @@ use Morcen\Passage\Concerns\HasResilienceOptions;
  */
 abstract class PassageHandler implements PassageControllerInterface
 {
-    use HasApiKeyAuth, HasBearerAuth, HasHmacAuth, HasResilienceOptions;
+    use HasApiKeyAuth, HasBearerAuth, HasHmacAuth, HasResilienceOptions, HasValidationHelpers;
 
     public function getRequest(Request $request): Request
     {

--- a/tests/Unit/ValidationHelpersTest.php
+++ b/tests/Unit/ValidationHelpersTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Morcen\Passage\Contracts\ValidatesInboundRequest;
+use Morcen\Passage\PassageHandler;
+
+// Fixture: handler using all validation helpers
+class ValidationHelperHandler extends PassageHandler implements ValidatesInboundRequest
+{
+    public function rules(): array
+    {
+        return [
+            'product_id'   => $this->requiredId(),
+            'email'        => $this->requiredEmail(),
+            'name'         => $this->requiredString(255),
+            'note'         => $this->optionalString(500),
+            'quantity'     => $this->requiredPositiveInt(),
+            'callback_url' => $this->requiredUrl(),
+            'status'       => $this->requiredIn('active', 'inactive'),
+            'priority'     => $this->optionalIn('low', 'medium', 'high'),
+            'amount'       => $this->requiredNumeric(),
+        ];
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/'];
+    }
+}
+
+describe('HasValidationHelpers', function () {
+    beforeEach(function () {
+        $this->handler = new ValidationHelperHandler;
+    });
+
+    it('returns required integer min:1 for requiredId', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['product_id'])->toBe(['required', 'integer', 'min:1']);
+    });
+
+    it('returns required email:rfc for requiredEmail', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['email'])->toBe(['required', 'email:rfc']);
+    });
+
+    it('returns required string with max for requiredString', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['name'])->toBe(['required', 'string', 'max:255']);
+    });
+
+    it('returns required string without max when no argument given', function () {
+        $handler = new class extends PassageHandler
+        {
+            public function getOptions(): array
+            {
+                return ['base_uri' => 'https://api.example.com/'];
+            }
+
+            public function getRules(): array
+            {
+                return $this->requiredString();
+            }
+        };
+
+        expect($handler->getRules())->toBe(['required', 'string']);
+    });
+
+    it('returns nullable string with max for optionalString', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['note'])->toBe(['nullable', 'string', 'max:500']);
+    });
+
+    it('returns nullable string without max when no argument given', function () {
+        $handler = new class extends PassageHandler
+        {
+            public function getOptions(): array
+            {
+                return ['base_uri' => 'https://api.example.com/'];
+            }
+
+            public function getRules(): array
+            {
+                return $this->optionalString();
+            }
+        };
+
+        expect($handler->getRules())->toBe(['nullable', 'string']);
+    });
+
+    it('returns required integer min:1 for requiredPositiveInt', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['quantity'])->toBe(['required', 'integer', 'min:1']);
+    });
+
+    it('returns required url for requiredUrl', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['callback_url'])->toBe(['required', 'url']);
+    });
+
+    it('returns required in:values for requiredIn', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['status'])->toBe(['required', 'in:active,inactive']);
+    });
+
+    it('returns nullable in:values for optionalIn', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['priority'])->toBe(['nullable', 'in:low,medium,high']);
+    });
+
+    it('returns required numeric for requiredNumeric', function () {
+        $rules = $this->handler->rules();
+
+        expect($rules['amount'])->toBe(['required', 'numeric']);
+    });
+});


### PR DESCRIPTION
 ## Summary
  - Adds `HasValidationHelpers` trait with 9 pre-composed rule helpers for common proxy validation     
  patterns
  - Adds `use HasValidationHelpers` to `PassageHandler` alongside existing traits
  - Helpers return plain Laravel rule arrays — zero magic, fully mixable with raw rules

  Closes #76

  ## Test plan
  - [x] All 11 new tests pass
  - [x] Full suite (104 tests) passes with no regressions