### PR TITLE
feat: scaffold retry-enabled handlers for passage:controller --with-retry

### DIFF
--- a/resources/stubs/controller.passage.retry.stub
+++ b/resources/stubs/controller.passage.retry.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Morcen\Passage\PassageHandler;
+
+class {{ class }} extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return array_merge(
+            ['base_uri' => 'https://api.example.com/'],
+            $this->withRetry(3, 200), // Retry failed requests 3 times, 200ms between attempts.
+        );
+    }
+}

--- a/src/Commands/PassageCommand.php
+++ b/src/Commands/PassageCommand.php
@@ -30,7 +30,7 @@ class PassageCommand extends Command
             return self::FAILURE;
         }
 
-        $stubType = $this->resolveStubType($authStyle, $withCache);
+        $stubType = $this->resolveStubType($authStyle, $withCache, $withRetry);
         Artisan::call("make:controller Passages/{$name} --type=passage{$stubType}");
 
         $this->info("Passage handler created at app/Http/Controllers/Passages/{$name}.php");
@@ -41,34 +41,36 @@ class PassageCommand extends Command
         $this->newLine();
         $this->line("    Passage::get('{your-prefix}/{path?}', {$name}::class);");
 
-        if ($withRetry) {
-            $this->newLine();
-            $this->info('Add retry support in getOptions():');
-            $this->newLine();
-            $this->line('    public function getOptions(): array');
-            $this->line('    {');
-            $this->line('        return array_merge(');
-            $this->line("            ['base_uri' => 'https://api.example.com/'],");
-            $this->line('            $this->withRetry(3, 200)');
-            $this->line('        );');
-            $this->line('    }');
-        }
-
         return self::SUCCESS;
     }
 
-    private function resolveStubType(?string $authStyle, bool $withCache): string
+    private function resolveStubType(?string $authStyle, bool $withCache, bool $withRetry): string
     {
         if ($authStyle !== null) {
             $style = strtolower($authStyle);
             if (in_array($style, ['bearer', 'apikey', 'hmac'], strict: true)) {
+                if ($withCache) {
+                    $this->warn('--with-cache is ignored when --with-auth is used. Add passage_cache_ttl to getOptions() manually if needed.');
+                }
+                if ($withRetry) {
+                    $this->warn('--with-retry is ignored when --with-auth is used. Add $this->withRetry() to getOptions() manually if needed.');
+                }
+
                 return ".{$style}";
             }
             $this->warn("Unknown --with-auth value '{$authStyle}'. Using the default stub.");
         }
 
         if ($withCache) {
+            if ($withRetry) {
+                $this->warn('--with-retry is ignored when --with-cache is used. Add $this->withRetry() to getOptions() manually if needed.');
+            }
+
             return '.cached';
+        }
+
+        if ($withRetry) {
+            return '.retry';
         }
 
         return '';

--- a/tests/Unit/PassageCommandTest.php
+++ b/tests/Unit/PassageCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+describe('PassageCommand', function () {
+    beforeEach(function () {
+        File::copyDirectory(__DIR__.'/../../resources/stubs', base_path('stubs'));
+    });
+
+    afterEach(function () {
+        File::deleteDirectory(base_path('stubs'));
+        File::deleteDirectory(app_path('Http/Controllers/Passages'));
+    });
+
+    it('generates a handler from the default stub', function () {
+        $this->artisan('passage:controller DefaultHandler')
+            ->expectsOutputToContain('Passage handler created at app/Http/Controllers/Passages/DefaultHandler.php')
+            ->assertExitCode(0);
+
+        $contents = File::get(app_path('Http/Controllers/Passages/DefaultHandler.php'));
+
+        expect($contents)
+            ->toContain('class DefaultHandler extends PassageHandler')
+            ->not->toContain('withRetry');
+    });
+
+    it('generates a retry-enabled handler with --with-retry', function () {
+        $this->artisan('passage:controller RetryHandler --with-retry')
+            ->assertExitCode(0);
+
+        $contents = File::get(app_path('Http/Controllers/Passages/RetryHandler.php'));
+
+        expect($contents)
+            ->toContain('$this->withRetry(3, 200)')
+            ->toContain('array_merge');
+    });
+
+    it('generates a cached handler with --with-cache', function () {
+        $this->artisan('passage:controller CachedHandler --with-cache')
+            ->assertExitCode(0);
+
+        $contents = File::get(app_path('Http/Controllers/Passages/CachedHandler.php'));
+
+        expect($contents)->toContain('passage_cache_ttl');
+    });
+
+    it('warns and prefers cache when --with-cache and --with-retry are combined', function () {
+        $this->artisan('passage:controller CacheRetryHandler --with-cache --with-retry')
+            ->expectsOutputToContain('--with-retry is ignored when --with-cache is used')
+            ->assertExitCode(0);
+
+        $contents = File::get(app_path('Http/Controllers/Passages/CacheRetryHandler.php'));
+
+        expect($contents)
+            ->toContain('passage_cache_ttl')
+            ->not->toContain('withRetry');
+    });
+
+    it('warns and prefers auth when --with-auth and --with-retry are combined', function () {
+        $this->artisan('passage:controller AuthRetryHandler --with-auth=bearer --with-retry')
+            ->expectsOutputToContain('--with-retry is ignored when --with-auth is used')
+            ->assertExitCode(0);
+
+        $contents = File::get(app_path('Http/Controllers/Passages/AuthRetryHandler.php'));
+
+        expect($contents)->not->toContain('$this->withRetry(3, 200)');
+    });
+
+    it('warns when --with-auth and --with-cache are combined', function () {
+        $this->artisan('passage:controller AuthCacheHandler --with-auth=bearer --with-cache')
+            ->expectsOutputToContain('--with-cache is ignored when --with-auth is used')
+            ->assertExitCode(0);
+    });
+
+    it('falls back to the retry stub when --with-auth is unknown and --with-retry is set', function () {
+        $this->artisan('passage:controller UnknownAuthRetryHandler --with-auth=oauth --with-retry')
+            ->expectsOutputToContain("Unknown --with-auth value 'oauth'")
+            ->assertExitCode(0);
+
+        $contents = File::get(app_path('Http/Controllers/Passages/UnknownAuthRetryHandler.php'));
+
+        expect($contents)->toContain('$this->withRetry(3, 200)');
+    });
+
+    it('fails when the handler already exists', function () {
+        $this->artisan('passage:controller DuplicateHandler --with-retry')
+            ->assertExitCode(0);
+
+        $this->artisan('passage:controller DuplicateHandler --with-retry')
+            ->expectsOutputToContain('already exists')
+            ->assertExitCode(1);
+    });
+});


### PR DESCRIPTION
## Summary

`passage:controller --with-retry` previously generated the default stub and printed a block of text telling the developer what to add manually. It now generates a handler with retry pre-wired in `getOptions()`, matching how the other scaffold flags behave.

Closes #66. Supersedes #72, which left the review feedback there unaddressed.

## Changes

**New stub: `resources/stubs/controller.passage.retry.stub`**
Generates a handler with `$this->withRetry(3, 200)` merged into `getOptions()`, as specified in the issue.

**`src/Commands/PassageCommand.php`**
- `resolveStubType()` now accepts `$withRetry` and returns `.retry`.
- Removed the manual retry guidance block from `handle()`. The generated file is self-explanatory.
- Added warnings when a scaffold flag is dropped by precedence (auth > cache > retry). Running `--with-cache --with-retry` or `--with-auth=bearer --with-retry` now tells the user which flag was ignored and how to add the option manually. This resolves the silent flag conflict raised in the #72 review.

**New tests: `tests/Unit/PassageCommandTest.php`**
8 tests covering the command end to end. They copy the package stubs into the testbench skeleton, run the command for real, and assert on generated file contents:
- default, retry, and cached stub generation
- warning plus correct stub for each flag conflict combination
- fallback to the retry stub when `--with-auth` has an unknown value
- failure when the handler already exists

This addresses the missing test coverage raised in the #72 review.

## Verification

- Full Pest suite passes: 101 tests, 254 assertions
- Pint passes on changed files