### PR TITLE
fix: resolve security audit advisories by allowing Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         php: [8.3, 8.2]
-        laravel: [11.*]
+        laravel: [11.*, 12.*]
         stability: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
+            carbon: ">=3.8.4"
+          - laravel: 12.*
+            testbench: 10.*
             carbon: ">=3.8.4"
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "laravel/pint": "^1.19.0",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "pestphp/pest": "^2.35.0|^3.0",
         "pestphp/pest-plugin-laravel": "^2.4.0|^3.0",
         "spatie/laravel-ray": "^1.37.0"


### PR DESCRIPTION
Widen orchestra/testbench to ^9.0|^10.0 so fresh installs resolve Laravel 12 with patched dependencies. Laravel 11 no longer receives security fixes, leaving 19 advisories across 10 locked packages (laravel/framework, guzzlehttp/guzzle, guzzlehttp/psr7, symfony/*).

Add Laravel 12 with testbench 10 to the test matrix so CI covers the versions fresh installs now resolve.