### PR TITLE
fix: include query string in Passage response cache key

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -108,7 +108,7 @@ class PassageController extends Controller
         $fullUrl = rtrim($mergedOptions['base_uri'], '/').'/'.$path;
 
         if ($cacheTtl !== null) {
-            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $guzzleOptions);
+            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $request->query());
             if ($cached !== null) {
                 $upstream = $handlerInstance->getResponse($request, $cached);
                 $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, 0.0, true));
@@ -132,7 +132,7 @@ class PassageController extends Controller
         $durationMs = (microtime(true) - $startedAt) * 1000;
 
         if ($cacheTtl !== null) {
-            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $upstream);
+            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $upstream, $request->query());
         }
 
         // Streaming: skip getResponse() hook and return directly.

--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -15,15 +15,16 @@ class PassageCacheManager
      *
      * @param  int  $ttl  Cache time-to-live in seconds.
      * @param  array  $options  Request options used to generate the cache key.
+     * @param  array  $query  Request query parameters used to generate the cache key.
      * @return Response|null Cached response, or null on a miss.
      */
-    public function get(string $method, string $fullUrl, int $ttl, array $options): ?Response
+    public function get(string $method, string $fullUrl, int $ttl, array $options, array $query = []): ?Response
     {
         if (! $this->isCacheable($method)) {
             return null;
         }
 
-        $cached = Cache::store($this->store())->get($this->key($method, $fullUrl, $options));
+        $cached = Cache::store($this->store())->get($this->key($method, $fullUrl, $options, $query));
 
         if ($cached === null) {
             return null;
@@ -39,15 +40,16 @@ class PassageCacheManager
      * @param  int  $ttl  Cache time-to-live in seconds.
      * @param  array  $options  Request options used to generate the cache key.
      * @param  Response  $response  The response to store.
+     * @param  array  $query  Request query parameters used to generate the cache key.
      */
-    public function put(string $method, string $fullUrl, int $ttl, array $options, Response $response): void
+    public function put(string $method, string $fullUrl, int $ttl, array $options, Response $response, array $query = []): void
     {
         if (! $this->isCacheable($method)) {
             return;
         }
 
         Cache::store($this->store())->put(
-            $this->key($method, $fullUrl, $options),
+            $this->key($method, $fullUrl, $options, $query),
             [
                 'status' => $response->status(),
                 'headers' => $response->headers(),
@@ -68,9 +70,11 @@ class PassageCacheManager
     /**
      * Generate a unique cache key for the request.
      */
-    private function key(string $method, string $fullUrl, array $options): string
+    private function key(string $method, string $fullUrl, array $options, array $query = []): string
     {
-        return 'passage:'.md5($method.$fullUrl.serialize($options));
+        ksort($query);
+
+        return 'passage:'.md5($method.$fullUrl.serialize($query).serialize($options));
     }
 
     /**

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -189,6 +189,29 @@ describe('3.2 Response caching', function () {
         expect($second->getStatusCode())->toBe(200);
     });
 
+    it('does not serve a cached response to a request with a different query string', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $requestPageOne = phase3Route(CachedHandler::class, '/proxy/items?page=1');
+        $requestPageTwo = phase3Route(CachedHandler::class, '/proxy/items?page=2');
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // Each distinct query string is a cache miss, so upstream is hit for both.
+        $this->mockService->shouldReceive('callService')
+            ->twice()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        $first = phase3Controller()->handle($requestPageOne);
+        $second = phase3Controller()->handle($requestPageTwo);
+
+        expect($first->getStatusCode())->toBe(200);
+        expect($second->getStatusCode())->toBe(200);
+    });
+
     it('does not cache non-GET methods', function () {
         Cache::flush();
         config(['passage.cache.store' => 'array']);


### PR DESCRIPTION
## What was broken

`PassageCacheManager::key()` built the cache key from `method + fullUrl + serialize($options)`. `$fullUrl` is assembled in `PassageController::handle()` from `base_uri` and the route `path` only — the request's query string is never included, even though query parameters are forwarded to the upstream service separately (`PassageService::callService()`).

As a result, any handler with `passage_cache_ttl` set shares one cache entry across all query-string variants of the same path. For example, `GET /users?page=1` and `GET /users?page=2` collide, so the second caller can receive the first caller's cached response — serving the wrong data in normal usage.

## What changed

- `PassageCacheManager::get()` and `::put()` now accept the request's query parameters and fold them (sorted, for a stable key regardless of parameter order) into the cache key via `key()`.
- `PassageController::handle()` passes `$request->query()` through to both the cache read and cache write calls.
- Added a regression test in `tests/Unit/Phase3Test.php` asserting that two requests to the same path with different query strings both hit upstream instead of sharing a cache entry.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` (full suite) — 102 passed, 258 assertions

Fixes #82

