### PR TITLE
chore(release): v3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "morcen/passage",
-    "version": "v3.0.0",
+    "version": "v3.1.0",
     "description": "API gateway for Laravel",
     "keywords": [
         "morcen",


### PR DESCRIPTION
Bumps the package version in `composer.json` from `v3.0.0` to `v3.1.0`.

This is a MINOR release: several `feat` commits have landed since `v3.0.0` with no breaking changes.

**Features**
- `feat: scaffold retry-enabled handlers for passage:controller --with-retry` — generates a dedicated retry stub for `passage:controller`, warns on conflicting scaffold flags (closes #66)
- `feat: add hmac controller stub` — adds an HMAC controller stub for `passage:controller`

**Fixes**
- `fix: include query string in Passage response cache key` — cached GET responses were previously keyed without the query string, causing requests with different query parameters to share a cache entry
- `fix: resolve security audit advisories by allowing Laravel 12` — widens `orchestra/testbench` to support Laravel 12
- `fix: make passage:list tolerate broken handlers`
- `fix: return JSON for invalid base URIs`
- `fix: normalize forwarded header casing` for uppercase header names

The remaining commits (docs, tests, style, CI/dependency bumps) are not user-facing and don't affect the version bump decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6n83L3prD5Gh3puBUVZw7)_