### PR TITLE
Fix unhandled 500 when a proxy target host is blocked

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -12,6 +12,7 @@ use Morcen\Passage\Contracts\ValidatesInboundRequest;
 use Morcen\Passage\Events\PassageRequestFailed;
 use Morcen\Passage\Events\PassageRequestSending;
 use Morcen\Passage\Events\PassageResponseReceived;
+use Morcen\Passage\Exceptions\DisallowedProxyTargetException;
 use Morcen\Passage\Exceptions\InvalidBaseUriException;
 use Morcen\Passage\Exceptions\PassageRequestAbortedException;
 use Morcen\Passage\Guards\AllowedHostsGuard;
@@ -66,6 +67,8 @@ class PassageController extends Controller
             $this->allowedHostsGuard->check($mergedOptions['base_uri']);
         } catch (InvalidBaseUriException $e) {
             return response()->json(['error' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+        } catch (DisallowedProxyTargetException $e) {
+            return response()->json(['error' => $e->getMessage()], Response::HTTP_FORBIDDEN);
         }
 
         // Extract Passage reserved keys before passing options to Guzzle.

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -116,6 +116,25 @@ class TestNoBaseUriPassageController implements PassageControllerInterface
     }
 }
 
+// Fixture: base_uri pointing at a host that can be disallowed via config
+class TestDisallowedHostPassageController implements PassageControllerInterface
+{
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.evil.com/'];
+    }
+}
+
 beforeEach(function () {
     $this->mockPassageService = Mockery::mock(PassageServiceInterface::class);
     $this->app->instance(PassageServiceInterface::class, $this->mockPassageService);
@@ -186,6 +205,28 @@ describe('PassageController', function () {
                 'Passage handler [%s] must return a \'base_uri\' from getOptions().',
                 TestNoBaseUriPassageController::class
             ),
+        ]);
+    });
+
+    it('returns a JSON 403 when the base_uri host is not in the allowed_hosts list', function () {
+        config([
+            'passage.security.enforce_allowed_hosts' => true,
+            'passage.security.allowed_hosts' => ['api.example.com'],
+        ]);
+
+        $request = Request::create('/blocked-host/test', 'GET');
+        $route = (new Route(['GET'], '/blocked-host/{path?}', []))
+            ->defaults('_passage_handler', TestDisallowedHostPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        Http::shouldReceive('withOptions')->never();
+
+        $response = $this->controller->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_FORBIDDEN);
+        expect(json_decode($response->getContent(), true))->toBe([
+            'error' => 'Upstream host [api.evil.com] is not in the passage allowed_hosts list.',
         ]);
     });
 


### PR DESCRIPTION
## What was broken

`AllowedHostsGuard::check()` throws `DisallowedProxyTargetException` when a handler's `base_uri` host is not in the configured `allowed_hosts` list. `PassageController::handle()` only caught `InvalidBaseUriException` around that call, so `DisallowedProxyTargetException` propagated as an unhandled exception, producing a generic 500 framework error page instead of a clean JSON response.

The `allowed_hosts` guard is a security feature meant to prevent open-proxy misconfigurations, but its failure mode leaked internals (a framework error page) and broke API clients expecting JSON error responses from Passage.

## What changed

- `src/Http/Controllers/PassageController.php`: catch `DisallowedProxyTargetException` alongside `InvalidBaseUriException` and return a JSON `403` response with the exception message.
- `tests/Unit/PassageControllerTest.php`: add a regression test that enables `enforce_allowed_hosts`, hits a route whose handler's `base_uri` targets a disallowed host, and asserts a JSON 403 response instead of a crash.

## Verification

- `vendor/bin/pint --dirty`: passed
- `composer test` (`vendor/bin/pest`): 104 tests passed, 262 assertions

Fixes #83.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb2oR3ptiNPTnHcas5pruL)_