### PR TITLE
Fix crash on multi-file array uploads in PassageService

### DIFF
--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -5,6 +5,7 @@ namespace Morcen\Passage\Services;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 class PassageService implements PassageServiceInterface
 {
@@ -36,12 +37,14 @@ class PassageService implements PassageServiceInterface
 
         if (count($request->allFiles()) > 0) {
             foreach ($request->allFiles() as $key => $file) {
-                $service = $service->attach(
-                    $key,
-                    $file->get(),
-                    $file->getClientOriginalName(),
-                    ['Content-Type' => $file->getMimeType()]
-                );
+                foreach (Arr::wrap($file) as $index => $singleFile) {
+                    $service = $service->attach(
+                        is_array($file) ? "{$key}[{$index}]" : $key,
+                        $singleFile->get(),
+                        $singleFile->getClientOriginalName(),
+                        ['Content-Type' => $singleFile->getMimeType()]
+                    );
+                }
             }
 
             return $service->{$method}($uri, $request->post());

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Morcen\Passage\Services\PassageService;
 use Symfony\Component\HttpFoundation\HeaderBag;
 
@@ -196,6 +197,45 @@ describe('PassageService::callService()', function () {
             $pending->shouldReceive('get')->andReturn(Mockery::mock(Response::class));
 
             $this->service->callService($request, $pending, 'test');
+        });
+    });
+
+    describe('file uploads', function () {
+        it('forwards a single uploaded file', function () {
+            $file = UploadedFile::fake()->create('avatar.png', 10, 'image/png');
+            $request = Request::create('/test', 'POST');
+            $request->files->set('avatar', $file);
+
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('attach')
+                ->once()
+                ->with('avatar', $file->get(), 'avatar.png', ['Content-Type' => 'image/png'])
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('upload', [])->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'upload'))->toBe($mockResponse);
+        });
+
+        it('forwards multiple files uploaded under the same field name without crashing', function () {
+            $file1 = UploadedFile::fake()->create('one.txt', 5, 'text/plain');
+            $file2 = UploadedFile::fake()->create('two.txt', 5, 'text/plain');
+            $request = Request::create('/test', 'POST');
+            $request->files->set('attachments', [$file1, $file2]);
+
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('attach')
+                ->once()
+                ->with('attachments[0]', $file1->get(), 'one.txt', ['Content-Type' => 'text/plain'])
+                ->andReturn($pending);
+            $pending->shouldReceive('attach')
+                ->once()
+                ->with('attachments[1]', $file2->get(), 'two.txt', ['Content-Type' => 'text/plain'])
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('upload', [])->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'upload'))->toBe($mockResponse);
         });
     });
 });


### PR DESCRIPTION
## What was broken

`PassageService::callService()` assumed every entry returned by `Request::allFiles()` was a single `Illuminate\Http\UploadedFile`. That holds for a single file field, but Laravel/Symfony's `FileBag` preserves array structure for array-style file inputs (e.g. multiple `<input type="file">` fields sharing a name, or repeated `FormData.append(key, file)` calls). For those fields, the value under a given key is an **array** of `UploadedFile` objects, not a single one.

Calling `->get()`, `->getClientOriginalName()`, or `->getMimeType()` directly on that array threw `Error: Call to a member function ... on array`, turning a standard multipart upload into an unhandled 500 response instead of a forwarded request. There was no test coverage for multipart uploads at all, so this was undetected.

## What changed

- `src/Services/PassageService.php`: the file-forwarding loop in `callService()` now wraps each entry with `Arr::wrap()` before attaching, handling both a single `UploadedFile` and an array of them. Files under an array field are re-attached with an indexed key (e.g. `attachments[0]`, `attachments[1]`).
- `tests/Unit/PassageServiceTest.php`: added regression tests covering a single file upload and multiple files uploaded under the same field name.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` — all 115 tests passing

Fixes #107

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwSAkUPh6uoawFrisjYPy)_