### PR TITLE
fix: include forwarded headers in cache key to prevent cross-user data leakage

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -22,6 +22,7 @@ use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
+use Morcen\Passage\Support\ForwardedHeaderResolver;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
@@ -125,9 +126,12 @@ class PassageController extends Controller
         // Check cache before making the upstream call.
         $cacheTtl = $passageOptions['passage_cache_ttl'] ?? null;
         $fullUrl = rtrim($mergedOptions['base_uri'], '/').'/'.$path;
+        // Same headers PassageService forwards upstream, so a cache entry is never
+        // shared between requests that carry different credentials/identity.
+        $forwardedHeaders = ForwardedHeaderResolver::resolve($request);
 
         if ($cacheTtl !== null) {
-            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $request->query());
+            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $request->query(), $forwardedHeaders);
             if ($cached !== null) {
                 $upstream = $handlerInstance->getResponse($request, $cached);
                 $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, 0.0, true));
@@ -151,7 +155,7 @@ class PassageController extends Controller
         $durationMs = (microtime(true) - $startedAt) * 1000;
 
         if ($cacheTtl !== null) {
-            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $upstream, $request->query());
+            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $upstream, $request->query(), $forwardedHeaders);
         }
 
         // Streaming: skip getResponse() hook and return directly.

--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -16,15 +16,18 @@ class PassageCacheManager
      * @param  int  $ttl  Cache time-to-live in seconds.
      * @param  array  $options  Request options used to generate the cache key.
      * @param  array  $query  Request query parameters used to generate the cache key.
+     * @param  array  $headers  Forwarded request headers used to generate the cache key, so
+     *                          requests carrying different credentials/identity never share
+     *                          a cached response.
      * @return Response|null Cached response, or null on a miss.
      */
-    public function get(string $method, string $fullUrl, int $ttl, array $options, array $query = []): ?Response
+    public function get(string $method, string $fullUrl, int $ttl, array $options, array $query = [], array $headers = []): ?Response
     {
         if (! $this->isCacheable($method)) {
             return null;
         }
 
-        $cached = Cache::store($this->store())->get($this->key($method, $fullUrl, $options, $query));
+        $cached = Cache::store($this->store())->get($this->key($method, $fullUrl, $options, $query, $headers));
 
         if ($cached === null) {
             return null;
@@ -41,15 +44,18 @@ class PassageCacheManager
      * @param  array  $options  Request options used to generate the cache key.
      * @param  Response  $response  The response to store.
      * @param  array  $query  Request query parameters used to generate the cache key.
+     * @param  array  $headers  Forwarded request headers used to generate the cache key, so
+     *                          requests carrying different credentials/identity never share
+     *                          a cached response.
      */
-    public function put(string $method, string $fullUrl, int $ttl, array $options, Response $response, array $query = []): void
+    public function put(string $method, string $fullUrl, int $ttl, array $options, Response $response, array $query = [], array $headers = []): void
     {
         if (! $this->isCacheable($method)) {
             return;
         }
 
         Cache::store($this->store())->put(
-            $this->key($method, $fullUrl, $options, $query),
+            $this->key($method, $fullUrl, $options, $query, $headers),
             [
                 'status' => $response->status(),
                 'headers' => $response->headers(),
@@ -69,12 +75,16 @@ class PassageCacheManager
 
     /**
      * Generate a unique cache key for the request.
+     *
+     * Forwarded headers (e.g. Authorization) are included so two requests that
+     * produce different outbound headers never share a cached response.
      */
-    private function key(string $method, string $fullUrl, array $options, array $query = []): string
+    private function key(string $method, string $fullUrl, array $options, array $query = [], array $headers = []): string
     {
         ksort($query);
+        ksort($headers);
 
-        return 'passage:'.md5($method.$fullUrl.serialize($query).serialize($options));
+        return 'passage:'.md5($method.$fullUrl.serialize($query).serialize($options).serialize($headers));
     }
 
     /**

--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -6,19 +6,14 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Morcen\Passage\Support\ForwardedHeaderResolver;
 
 class PassageService implements PassageServiceInterface
 {
-    // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
-    private const HOP_BY_HOP_FALLBACK = [
-        'host', 'connection', 'transfer-encoding', 'upgrade',
-        'keep-alive', 'te', 'trailer', 'proxy-authenticate',
-    ];
-
     public function callService(Request $request, PendingRequest $service, string $uri): Response
     {
         $method = strtolower($request->method());
-        $service = $service->withHeaders($this->resolveForwardedHeaders($request));
+        $service = $service->withHeaders(ForwardedHeaderResolver::resolve($request));
 
         if (in_array($method, ['get', 'head'])) {
             return $service->{$method}($uri, $request->query());
@@ -65,23 +60,5 @@ class PassageService implements PassageServiceInterface
         }
 
         return $service->{$method}($uri);
-    }
-
-    private function resolveForwardedHeaders(Request $request): array
-    {
-        $hopByHop = config('passage.security.hop_by_hop_headers', self::HOP_BY_HOP_FALLBACK);
-        $headers = [];
-
-        foreach ($request->headers->all() as $name => $values) {
-            if (in_array(strtolower($name), $hopByHop, strict: true)) {
-                continue;
-            }
-            // Convert to HTTP title-case (e.g. authorization → Authorization,
-            // x-request-id → X-Request-Id) so header key lookups work correctly.
-            $titleName = ucwords(strtolower($name), '-');
-            $headers[$titleName] = implode(', ', $values);
-        }
-
-        return $headers;
     }
 }

--- a/src/Support/ForwardedHeaderResolver.php
+++ b/src/Support/ForwardedHeaderResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Morcen\Passage\Support;
+
+use Illuminate\Http\Request;
+
+/**
+ * Resolves the set of headers Passage forwards upstream for a given request,
+ * stripping hop-by-hop headers per RFC 7230.
+ *
+ * Shared by PassageService (to build the outbound request) and
+ * PassageCacheManager (to key cached responses by the credentials/identity
+ * headers that were actually sent), so the two never disagree about what
+ * was forwarded.
+ */
+class ForwardedHeaderResolver
+{
+    // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
+    private const HOP_BY_HOP_FALLBACK = [
+        'host', 'connection', 'transfer-encoding', 'upgrade',
+        'keep-alive', 'te', 'trailer', 'proxy-authenticate',
+    ];
+
+    public static function resolve(Request $request): array
+    {
+        $hopByHop = config('passage.security.hop_by_hop_headers', self::HOP_BY_HOP_FALLBACK);
+        $headers = [];
+
+        foreach ($request->headers->all() as $name => $values) {
+            if (in_array(strtolower($name), $hopByHop, strict: true)) {
+                continue;
+            }
+            // Convert to HTTP title-case (e.g. authorization → Authorization,
+            // x-request-id → X-Request-Id) so header key lookups work correctly.
+            $titleName = ucwords(strtolower($name), '-');
+            $headers[$titleName] = implode(', ', $values);
+        }
+
+        return $headers;
+    }
+}

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Morcen\Passage\Concerns\HasResilienceOptions;
+use Morcen\Passage\Contracts\AcceptsClientHeaders;
 use Morcen\Passage\Events\PassageRequestFailed;
 use Morcen\Passage\Events\PassageRequestSending;
 use Morcen\Passage\Events\PassageResponseReceived;
@@ -40,6 +41,19 @@ class RetryableHandler extends PassageHandler
 
 class CachedHandler extends PassageHandler
 {
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/', 'passage_cache_ttl' => 60];
+    }
+}
+
+class CachedHandlerAcceptingAuth extends PassageHandler implements AcceptsClientHeaders
+{
+    public function allowedClientHeaders(): array
+    {
+        return ['authorization'];
+    }
+
     public function getOptions(): array
     {
         return ['base_uri' => 'https://api.example.com/', 'passage_cache_ttl' => 60];
@@ -210,6 +224,59 @@ describe('3.2 Response caching', function () {
 
         expect($first->getStatusCode())->toBe(200);
         expect($second->getStatusCode())->toBe(200);
+    });
+
+    it('does not serve a cached response to a request with a different Authorization header', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $requestUserOne = phase3Route(CachedHandlerAcceptingAuth::class);
+        $requestUserOne->headers->set('Authorization', 'Bearer user-one-token');
+
+        $requestUserTwo = phase3Route(CachedHandlerAcceptingAuth::class);
+        $requestUserTwo->headers->set('Authorization', 'Bearer user-two-token');
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // Each distinct Authorization header is a cache miss, so upstream is hit for
+        // both requests — user two must never be served user one's cached response.
+        $this->mockService->shouldReceive('callService')
+            ->twice()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        $first = phase3Controller()->handle($requestUserOne);
+        $second = phase3Controller()->handle($requestUserTwo);
+
+        expect($first->getStatusCode())->toBe(200);
+        expect($second->getStatusCode())->toBe(200);
+    });
+
+    it('serves a cached response to a request with the same Authorization header', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $first = phase3Route(CachedHandlerAcceptingAuth::class);
+        $first->headers->set('Authorization', 'Bearer same-token');
+
+        $second = phase3Route(CachedHandlerAcceptingAuth::class);
+        $second->headers->set('Authorization', 'Bearer same-token');
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // Same Authorization header on both requests: only the first hits upstream.
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        $firstResponse = phase3Controller()->handle($first);
+        $secondResponse = phase3Controller()->handle($second);
+
+        expect($firstResponse->getStatusCode())->toBe(200);
+        expect($secondResponse->getStatusCode())->toBe(200);
     });
 
     it('does not cache non-GET methods', function () {


### PR DESCRIPTION
## What was broken

`PassageCacheManager::key()` built the cache key from the HTTP method, full URL, query string, and the static Guzzle options only — it never included the inbound request headers (`src/Http/PassageCacheManager.php`).

A common, documented Passage pattern is a handler that combines `passage_cache_ttl` with forwarding the client's own `Authorization` header (e.g. via `AcceptsClientHeaders`) to fetch caller-specific data ("my profile", "my orders") from an upstream API. Because the cache key was identical for every caller hitting the same route/query regardless of credentials, the **first** user's response got cached and served to **every subsequent caller** hitting the same route within the TTL window — a cross-user data leak, not just a correctness bug.

## What changed

- Extracted the header-forwarding logic that `PassageService` already used to build outbound requests into a shared `Morcen\Passage\Support\ForwardedHeaderResolver` (hop-by-hop headers stripped per RFC 7230, same as before).
- `PassageController::handle()` now resolves the forwarded headers once (after client-header stripping and any `getRequest()` transform, so it reflects exactly what actually goes upstream) and passes them to `PassageCacheManager::get()`/`put()`.
- `PassageCacheManager::key()` folds a sorted/serialized copy of those headers into the cache key, so two requests that produce different outbound headers (different `Authorization`, etc.) never share a cached entry. Requests with identical forwarded headers still share the cache as before.

## Tests

Added regression tests in `tests/Unit/Phase3Test.php`:
- a request with a different `Authorization` header is never served another caller's cached response (upstream is hit for both).
- a request with the same `Authorization` header still gets served from cache (no cache-hit regression).

## Test plan

- [x] `vendor/bin/pint --dirty` — passed
- [x] `vendor/bin/pest` — full suite passes (117 tests)

Fixes #111


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdyyowvsrZ6XF2HPLeojng)_