### PR TITLE
Re-validate redirect targets against allowed_hosts to prevent SSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Then list the permitted upstream hostnames in `config/passage.php`:
 
 Any handler whose `base_uri` resolves to a host not in the list will throw `DisallowedProxyTargetException` instead of forwarding the request.
 
+When enabled, the guard also re-validates every upstream redirect hop: if an allowed host responds with a redirect to a host outside `allowed_hosts`, Passage aborts the request with a 403 instead of following it. To opt a specific handler out of redirect-following entirely, set `'allow_redirects' => false` in its `getOptions()`.
+
 ### Aborting a request from a handler
 
 To abort a request early with a specific HTTP status, throw `PassageRequestAbortedException` inside `getRequest()`:

--- a/src/Guards/AllowedHostsGuard.php
+++ b/src/Guards/AllowedHostsGuard.php
@@ -29,6 +29,24 @@ class AllowedHostsGuard
             );
         }
 
+        $this->checkHost($host);
+    }
+
+    /**
+     * Assert that the given host is permitted as an upstream proxy target.
+     *
+     * Used both for the initial base_uri check and to re-validate each hop
+     * of an upstream redirect, so that a redirect issued by an allowlisted
+     * host cannot be used to reach a host outside the allowlist.
+     *
+     * @throws DisallowedProxyTargetException
+     */
+    public function checkHost(string $host): void
+    {
+        if (! config('passage.security.enforce_allowed_hosts', false)) {
+            return;
+        }
+
         $allowedHosts = config('passage.security.allowed_hosts', []);
 
         if (! in_array($host, $allowedHosts, strict: true)) {

--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -84,6 +84,10 @@ class PassageController extends Controller
         // Extract Passage reserved keys before passing options to Guzzle.
         [$passageOptions, $guzzleOptions] = $this->extractPassageOptions($mergedOptions);
 
+        if (config('passage.security.enforce_allowed_hosts', false)) {
+            $guzzleOptions['allow_redirects'] = $this->guardRedirects($guzzleOptions['allow_redirects'] ?? true);
+        }
+
         $pendingRequest = Http::withOptions($guzzleOptions);
 
         if (isset($passageOptions['passage_retry_times'])) {
@@ -145,6 +149,11 @@ class PassageController extends Controller
 
         try {
             $upstream = $this->passageService->callService($request, $pendingRequest, $path);
+        } catch (DisallowedProxyTargetException $e) {
+            $durationMs = (microtime(true) - $startedAt) * 1000;
+            $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));
+
+            return response()->json(['error' => $e->getMessage()], Response::HTTP_FORBIDDEN);
         } catch (ConnectionException|Throwable $e) {
             $durationMs = (microtime(true) - $startedAt) * 1000;
             $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));
@@ -190,6 +199,33 @@ class PassageController extends Controller
         }
 
         return [$passage, $guzzle];
+    }
+
+    /**
+     * Wrap the resolved allow_redirects Guzzle option so every redirect hop
+     * is re-validated against the allowed_hosts list before it is followed.
+     *
+     * Prevents an allowlisted upstream from bypassing enforce_allowed_hosts
+     * by issuing a redirect to a host outside the allowlist.
+     */
+    private function guardRedirects(mixed $allowRedirects): array|false
+    {
+        if ($allowRedirects === false) {
+            return false;
+        }
+
+        $settings = is_array($allowRedirects) ? $allowRedirects : [];
+        $previousOnRedirect = $settings['on_redirect'] ?? null;
+
+        $settings['on_redirect'] = function ($request, $response, $uri) use ($previousOnRedirect) {
+            $this->allowedHostsGuard->checkHost($uri->getHost());
+
+            if ($previousOnRedirect !== null) {
+                $previousOnRedirect($request, $response, $uri);
+            }
+        };
+
+        return $settings;
     }
 
     private function fireEvent(object $event): void

--- a/tests/Feature/PassageIntegrationTest.php
+++ b/tests/Feature/PassageIntegrationTest.php
@@ -197,6 +197,43 @@ describe('Passage Integration Tests', function () {
         });
     });
 
+    describe('enforce_allowed_hosts redirect protection', function () {
+        it('does not follow an upstream redirect to a host outside allowed_hosts', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => true,
+                'passage.security.allowed_hosts' => ['api.example.com'],
+            ]);
+
+            Http::fake([
+                'https://api.example.com/*' => Http::response('', 302, ['Location' => 'https://evil.example.com/steal']),
+                'https://evil.example.com/*' => Http::response(['secret' => 'leaked'], 200),
+            ]);
+            Passage::get('redirect-guard/{path?}', IntegrationTestPassageController::class);
+
+            $response = $this->get('/redirect-guard/resource');
+
+            $response->assertStatus(403);
+            Http::assertNotSent(fn ($req) => str_contains($req->url(), 'evil.example.com'));
+        });
+
+        it('still follows an upstream redirect to another allowed host', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => true,
+                'passage.security.allowed_hosts' => ['api.example.com'],
+            ]);
+
+            Http::fake([
+                'https://api.example.com/entry' => Http::response('', 302, ['Location' => 'https://api.example.com/final']),
+                'https://api.example.com/final' => Http::response(['ok' => true], 200),
+            ]);
+            Passage::get('redirect-ok/{path?}', IntegrationTestPassageController::class);
+
+            $response = $this->get('/redirect-ok/entry');
+
+            $response->assertStatus(200)->assertJson(['ok' => true]);
+        });
+    });
+
     describe('route registration', function () {
         it('returns 404 without proxying when Passage is disabled', function () {
             Http::fake();

--- a/tests/Unit/AllowedHostsGuardTest.php
+++ b/tests/Unit/AllowedHostsGuardTest.php
@@ -49,4 +49,34 @@ describe('AllowedHostsGuard', function () {
                 ->toThrow(DisallowedProxyTargetException::class);
         });
     });
+
+    describe('checkHost()', function () {
+        it('permits any host when enforce_allowed_hosts is false', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => false,
+                'passage.security.allowed_hosts' => [],
+            ]);
+
+            expect(fn () => $this->guard->checkHost('evil.example.com'))->not->toThrow(DisallowedProxyTargetException::class);
+        });
+
+        it('permits an allowlisted host when enforce_allowed_hosts is true', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => true,
+                'passage.security.allowed_hosts' => ['api.github.com'],
+            ]);
+
+            expect(fn () => $this->guard->checkHost('api.github.com'))->not->toThrow(DisallowedProxyTargetException::class);
+        });
+
+        it('throws for a host outside the allowlist, e.g. a redirect target', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => true,
+                'passage.security.allowed_hosts' => ['api.github.com'],
+            ]);
+
+            expect(fn () => $this->guard->checkHost('evil.example.com'))
+                ->toThrow(DisallowedProxyTargetException::class);
+        });
+    });
 });

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Http;
+use Morcen\Passage\Exceptions\DisallowedProxyTargetException;
 use Morcen\Passage\Exceptions\PassageRequestAbortedException;
 use Morcen\Passage\Guards\AllowedHostsGuard;
 use Morcen\Passage\Http\Controllers\PassageController;
@@ -13,6 +14,9 @@ use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 use Symfony\Component\HttpFoundation\Response as ResponseCode;
 
 // Fixture: transforms both request and response
@@ -135,6 +139,25 @@ class TestDisallowedHostPassageController implements PassageControllerInterface
     }
 }
 
+// Fixture: explicitly disables redirect following
+class TestNoRedirectsPassageController implements PassageControllerInterface
+{
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.custom.com/', 'allow_redirects' => false];
+    }
+}
+
 beforeEach(function () {
     $this->mockPassageService = Mockery::mock(PassageServiceInterface::class);
     $this->app->instance(PassageServiceInterface::class, $this->mockPassageService);
@@ -228,6 +251,113 @@ describe('PassageController', function () {
         expect(json_decode($response->getContent(), true))->toBe([
             'error' => 'Upstream host [api.evil.com] is not in the passage allowed_hosts list.',
         ]);
+    });
+
+    it('returns a JSON 403 when an upstream redirect targets a host outside allowed_hosts', function () {
+        config([
+            'passage.security.enforce_allowed_hosts' => true,
+            'passage.security.allowed_hosts' => ['api.custom.com'],
+        ]);
+
+        $request = Request::create('/github/users/123', 'GET');
+        $route = (new Route(['GET'], '/github/{path?}', []))
+            ->defaults('_passage_handler', TestPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        $mockPendingRequest = Mockery::mock(PendingRequest::class);
+        Http::shouldReceive('withOptions')->once()->andReturn($mockPendingRequest);
+
+        // Simulates the on_redirect guard rejecting a redirect hop mid-request.
+        $this->mockPassageService->shouldReceive('callService')
+            ->once()
+            ->andThrow(new DisallowedProxyTargetException(
+                'Upstream host [evil.example.com] is not in the passage allowed_hosts list.'
+            ));
+
+        $response = $this->controller->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_FORBIDDEN);
+        expect(json_decode($response->getContent(), true))->toBe([
+            'error' => 'Upstream host [evil.example.com] is not in the passage allowed_hosts list.',
+        ]);
+    });
+
+    it('wires an on_redirect guard into allow_redirects that blocks disallowed redirect hosts', function () {
+        config([
+            'passage.security.enforce_allowed_hosts' => true,
+            'passage.security.allowed_hosts' => ['api.custom.com'],
+        ]);
+
+        $request = Request::create('/github/users/123', 'GET');
+        $route = (new Route(['GET'], '/github/{path?}', []))
+            ->defaults('_passage_handler', TestPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        $capturedOptions = null;
+        $mockPendingRequest = Mockery::mock(PendingRequest::class);
+        Http::shouldReceive('withOptions')
+            ->once()
+            ->withArgs(function (array $options) use (&$capturedOptions) {
+                $capturedOptions = $options;
+
+                return true;
+            })
+            ->andReturn($mockPendingRequest);
+
+        $mockResponse = jsonUpstreamResponse(['id' => 123]);
+        $this->mockPassageService->shouldReceive('callService')->once()->andReturn($mockResponse);
+
+        $this->controller->handle($request);
+
+        expect($capturedOptions['allow_redirects'])->toBeArray();
+        $onRedirect = $capturedOptions['allow_redirects']['on_redirect'];
+        expect($onRedirect)->toBeCallable();
+
+        $psrRequest = Mockery::mock(RequestInterface::class);
+        $psrResponse = Mockery::mock(ResponseInterface::class);
+
+        $allowedUri = Mockery::mock(UriInterface::class);
+        $allowedUri->shouldReceive('getHost')->andReturn('api.custom.com');
+        expect(fn () => $onRedirect($psrRequest, $psrResponse, $allowedUri))
+            ->not->toThrow(DisallowedProxyTargetException::class);
+
+        $disallowedUri = Mockery::mock(UriInterface::class);
+        $disallowedUri->shouldReceive('getHost')->andReturn('evil.example.com');
+        expect(fn () => $onRedirect($psrRequest, $psrResponse, $disallowedUri))
+            ->toThrow(DisallowedProxyTargetException::class);
+    });
+
+    it('does not wire an on_redirect guard when allow_redirects is explicitly disabled', function () {
+        config([
+            'passage.security.enforce_allowed_hosts' => true,
+            'passage.security.allowed_hosts' => ['api.custom.com'],
+        ]);
+
+        $request = Request::create('/no-redirects/users/123', 'GET');
+        $route = (new Route(['GET'], '/no-redirects/{path?}', []))
+            ->defaults('_passage_handler', TestNoRedirectsPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        $capturedOptions = null;
+        $mockPendingRequest = Mockery::mock(PendingRequest::class);
+        Http::shouldReceive('withOptions')
+            ->once()
+            ->withArgs(function (array $options) use (&$capturedOptions) {
+                $capturedOptions = $options;
+
+                return true;
+            })
+            ->andReturn($mockPendingRequest);
+
+        $mockResponse = jsonUpstreamResponse(['id' => 123]);
+        $this->mockPassageService->shouldReceive('callService')->once()->andReturn($mockResponse);
+
+        $this->controller->handle($request);
+
+        expect($capturedOptions['allow_redirects'])->toBeFalse();
     });
 
     it('proxies a basic GET request and returns JSON response', function () {


### PR DESCRIPTION
## What was broken

`AllowedHostsGuard::check()` is only ever called once per request, against the static, handler-declared `base_uri`. After that check passes, the actual upstream call goes through Guzzle, which follows redirects by default (`allow_redirects => true`, up to 5 hops) and nothing re-validates the redirect target's host.

This meant that with `enforce_allowed_hosts` enabled (the documented production hardening setting), an allowlisted upstream host could redirect Passage to a disallowed or internal host — e.g. a cloud metadata endpoint, an internal admin panel, or `localhost` — and the request would be silently followed, completely bypassing the allowlist. No test exercised a redirect at all, so this gap had zero coverage.

## What changed

- `AllowedHostsGuard` gains a `checkHost(string $host)` method (extracted from `check()`) that validates a bare host against `allowed_hosts` without needing a full `base_uri` string.
- `PassageController::handle()` now wires an `on_redirect` Guzzle callback into `allow_redirects` whenever `enforce_allowed_hosts` is on. The callback re-validates every redirect hop's host via `AllowedHostsGuard::checkHost()` before Guzzle follows it, aborting with a 403 (`DisallowedProxyTargetException`) the moment a hop leaves the allowlist. A handler that explicitly sets `allow_redirects => false` is left untouched, and any handler-supplied `on_redirect` callback is still invoked after the guard.
- Added unit tests for `checkHost()`, unit tests verifying the controller wires the guard correctly (and returns a 403 on a blocked hop) and leaves redirects disabled when a handler opts out, and an end-to-end integration test proving a redirect to a disallowed host is never followed while a redirect to another allowlisted host still succeeds.
- Documented the new behavior in the README's "Allowed hosts guard" section.

## Test plan

- [x] `vendor/bin/pint` — no formatting issues
- [x] `composer test` — full suite passes (125 tests, 331 assertions)

Fixes #112


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm7cBpjn5Q5Uueg1C7DMbM)_