### PR TITLE
Sign parsed fields instead of empty body for multipart HMAC requests

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -3,6 +3,7 @@
 namespace Morcen\Passage\Concerns;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 trait HasHmacAuth
 {
@@ -27,7 +28,7 @@ trait HasHmacAuth
         string $signatureHeader = 'X-Signature'
     ): Request {
         $timestamp = (string) time();
-        $body = $request->getContent();
+        $body = $this->resolveHmacSignedBody($request);
         $payload = $timestamp.'.'.$body;
         $signature = hash_hmac($algorithm, $payload, $secret);
 
@@ -35,5 +36,37 @@ trait HasHmacAuth
         $request->headers->set($signatureHeader, $signature);
 
         return $request;
+    }
+
+    /**
+     * Resolve the payload to sign.
+     *
+     * PHP consumes php://input while populating $_POST/$_FILES for
+     * multipart/form-data requests, so getContent() is always empty for
+     * them. Sign a stable representation of the parsed fields and file
+     * metadata instead, so the signature still covers what was submitted.
+     */
+    private function resolveHmacSignedBody(Request $request): string
+    {
+        if (! str_contains($request->header('Content-Type', ''), 'multipart/form-data')) {
+            return $request->getContent();
+        }
+
+        $files = [];
+
+        foreach ($request->allFiles() as $key => $file) {
+            foreach (Arr::wrap($file) as $index => $singleFile) {
+                $files[is_array($file) ? "{$key}[{$index}]" : $key] = [
+                    'name' => $singleFile->getClientOriginalName(),
+                    'size' => $singleFile->getSize(),
+                    'mime' => $singleFile->getMimeType(),
+                ];
+            }
+        }
+
+        return json_encode([
+            'fields' => $request->post(),
+            'files' => $files,
+        ]);
     }
 }

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -188,6 +188,55 @@ describe('HasHmacAuth', function () {
         $expected = hash_hmac('sha512', $timestamp.'.', 'super-secret');
         expect($result->header('X-Req-Sig'))->toBe($expected);
     });
+
+    it('signs the parsed fields of a multipart request instead of the empty raw body', function () {
+        $handler = new HmacHandler;
+
+        // Mirrors PHP's real behavior: multipart requests consume php://input
+        // into $_POST before userland code runs, so getContent() is empty.
+        $request = Request::create('/test', 'POST', ['field1' => 'hello', 'field2' => 'world'], [], [], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+
+        $result = $handler->getRequest($request);
+
+        $timestamp = $result->header('X-Timestamp');
+        $signature = $result->header('X-Signature');
+        $expectedPayload = $timestamp.'.'.json_encode([
+            'fields' => ['field1' => 'hello', 'field2' => 'world'],
+            'files' => [],
+        ]);
+
+        expect($signature)->toBe(hash_hmac('sha256', $expectedPayload, 'super-secret'));
+    });
+
+    it('produces different signatures for multipart requests with different field values', function () {
+        $handlerA = new HmacHandler;
+        $handlerB = new HmacHandler;
+
+        $requestA = Request::create('/test', 'POST', ['field1' => 'hello'], [], [], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+        $requestB = Request::create('/test', 'POST', ['field1' => 'goodbye'], [], [], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+
+        $resultA = $handlerA->getRequest($requestA);
+        $resultB = $handlerB->getRequest($requestB);
+
+        $expectedA = hash_hmac('sha256', $resultA->header('X-Timestamp').'.'.json_encode([
+            'fields' => ['field1' => 'hello'],
+            'files' => [],
+        ]), 'super-secret');
+        $expectedB = hash_hmac('sha256', $resultB->header('X-Timestamp').'.'.json_encode([
+            'fields' => ['field1' => 'goodbye'],
+            'files' => [],
+        ]), 'super-secret');
+
+        expect($resultA->header('X-Signature'))->toBe($expectedA);
+        expect($resultB->header('X-Signature'))->toBe($expectedB);
+        expect($resultA->header('X-Signature'))->not->toBe($resultB->header('X-Signature'));
+    });
 });
 
 describe('PassageHandler base class', function () {


### PR DESCRIPTION
## What was broken

`HasHmacAuth::withHmacSignature()` computes the HMAC payload as `"$timestamp.".$request->getContent()`. PHP consumes `php://input` while populating `$_POST`/`$_FILES` during SAPI request initialization for `multipart/form-data` requests, before any userland/framework code runs. This means `$request->getContent()` is always an empty string for multipart requests, so the signature only ever covered the timestamp — never the actual submitted fields.

This silently defeats the integrity guarantee the trait exists to provide: for any handler signing a multipart request (e.g. a partner API integration using `withHmacSignature()`), two requests with completely different form fields/files produced the identical signature. An attacker able to tamper with multipart fields in transit would not invalidate the signature, contradicting the documented behavior ("signs the request body and a timestamp").

## What changed

- `withHmacSignature()` now resolves the payload to sign via a new `resolveHmacSignedBody()` helper. For non-multipart requests, behavior is unchanged (`$request->getContent()`). For `multipart/form-data` requests, it builds a stable JSON representation of `$request->post()` fields plus file metadata (name, size, mime) from `$request->allFiles()`, so the signature actually covers what was submitted.
- Added regression tests in `tests/Unit/AuthTraitsTest.php` asserting the signature is computed from the parsed multipart fields, and that different field values produce different signatures.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` — 127 passed (335 assertions)

Fixes #118

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmLs8wzyHVJSRffPdTp8Qf)_