### PR TITLE
fix: exclude injected redirect-guard closure from cache key

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -84,6 +84,12 @@ class PassageController extends Controller
         // Extract Passage reserved keys before passing options to Guzzle.
         [$passageOptions, $guzzleOptions] = $this->extractPassageOptions($mergedOptions);
 
+        // Snapshot before the redirect guard below injects a Closure into
+        // allow_redirects: PassageCacheManager builds its cache key with
+        // serialize(), which throws on Closures, and the guard closure has
+        // no bearing on cached response content anyway.
+        $cacheableOptions = $guzzleOptions;
+
         if (config('passage.security.enforce_allowed_hosts', false)) {
             $guzzleOptions['allow_redirects'] = $this->guardRedirects($guzzleOptions['allow_redirects'] ?? true);
         }
@@ -135,7 +141,7 @@ class PassageController extends Controller
         $forwardedHeaders = ForwardedHeaderResolver::resolve($request);
 
         if ($cacheTtl !== null) {
-            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $request->query(), $forwardedHeaders);
+            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $cacheableOptions, $request->query(), $forwardedHeaders);
             if ($cached !== null) {
                 $upstream = $handlerInstance->getResponse($request, $cached);
                 $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, 0.0, true));
@@ -164,7 +170,7 @@ class PassageController extends Controller
         $durationMs = (microtime(true) - $startedAt) * 1000;
 
         if ($cacheTtl !== null) {
-            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $guzzleOptions, $upstream, $request->query(), $forwardedHeaders);
+            $this->cacheManager->put($request->method(), $fullUrl, $cacheTtl, $cacheableOptions, $upstream, $request->query(), $forwardedHeaders);
         }
 
         // Streaming: skip getResponse() hook and return directly.

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -328,6 +328,32 @@ describe('3.2 Response caching', function () {
 
         phase3Controller()->handle($request);
     });
+
+    it('serves a cached GET response when enforce_allowed_hosts is also enabled', function () {
+        // Regression test for #122: enforce_allowed_hosts injects an on_redirect
+        // Closure into allow_redirects, which used to reach
+        // PassageCacheManager::key()'s serialize() call and crash every request.
+        Cache::flush();
+        config([
+            'passage.cache.store' => 'array',
+            'passage.security.enforce_allowed_hosts' => true,
+            'passage.security.allowed_hosts' => ['api.example.com'],
+        ]);
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        $first = phase3Controller()->handle(phase3Route(CachedHandler::class));
+        $second = phase3Controller()->handle(phase3Route(CachedHandler::class));
+
+        expect($first->getStatusCode())->toBe(200);
+        expect($second->getStatusCode())->toBe(200);
+    });
 });
 
 describe('3.3 Upstream error handling', function () {


### PR DESCRIPTION
## What was broken

`PassageController::handle()` builds Guzzle options, and when `enforce_allowed_hosts` is enabled it injects a `Closure` into `$guzzleOptions['allow_redirects']['on_redirect']` to re-validate every redirect hop against the allowlist (added in #117).

That same `$guzzleOptions` array — now containing the closure — was passed straight into `PassageCacheManager::get()`/`put()` whenever a route also set `passage_cache_ttl`. `PassageCacheManager::key()` builds the cache key with `serialize($options)`, and `serialize()` throws `Exception: Serialization of 'Closure' is not allowed`.

Since this call happens outside the controller's `try`/`catch` around the upstream call, the exception was completely uncaught and propagated to Laravel's default exception handler — every single request to a route configured with both `enforce_allowed_hosts: true` and `passage_cache_ttl` set crashed with a 500, including plain GET requests that never actually redirect. Both settings are independently documented as recommended production configuration in the README, so this combination is not an edge case.

## What changed

`PassageController::handle()` now snapshots `$guzzleOptions` into `$cacheableOptions` *before* the redirect-guard closure is injected, and passes `$cacheableOptions` (never the closure) into the cache manager. The closure has no bearing on cached response content, so this doesn't change caching semantics — it just keeps a non-serializable, Passage-internal value out of the cache-key inputs.

## Tests

Added a regression test in `tests/Unit/Phase3Test.php` (`3.2 Response caching`) that enables both `enforce_allowed_hosts` and `passage_cache_ttl` on the same route and asserts the request succeeds and the second call is served from cache without hitting upstream — this reproduces the crash on `main` and passes with the fix.

Full suite (`composer test`, 128 tests) passes.

Fixes #122

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2VYWvzycuzQhDXktbvmjN)_