### PR TITLE
Fix HMAC multipart signing silently degrading on invalid UTF-8

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -4,6 +4,7 @@ namespace Morcen\Passage\Concerns;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use RuntimeException;
 
 trait HasHmacAuth
 {
@@ -64,9 +65,15 @@ trait HasHmacAuth
             }
         }
 
-        return json_encode([
+        $encoded = json_encode([
             'fields' => $request->post(),
             'files' => $files,
-        ]);
+        ], JSON_INVALID_UTF8_SUBSTITUTE);
+
+        if ($encoded === false) {
+            throw new RuntimeException('Unable to encode multipart fields for HMAC signing: '.json_last_error_msg());
+        }
+
+        return $encoded;
     }
 }

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -237,6 +237,27 @@ describe('HasHmacAuth', function () {
         expect($resultB->header('X-Signature'))->toBe($expectedB);
         expect($resultA->header('X-Signature'))->not->toBe($resultB->header('X-Signature'));
     });
+
+    it('still signs actual field content when a multipart field contains invalid UTF-8 bytes', function () {
+        $handler = new HmacHandler;
+        $invalid = "\xB1\x31";
+
+        $request = Request::create('/test', 'POST', ['comment' => $invalid], [], [], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+
+        $result = $handler->getRequest($request);
+
+        $timestamp = $result->header('X-Timestamp');
+        $signature = $result->header('X-Signature');
+        $expectedPayload = $timestamp.'.'.json_encode([
+            'fields' => ['comment' => $invalid],
+            'files' => [],
+        ], JSON_INVALID_UTF8_SUBSTITUTE);
+
+        expect($signature)->toBe(hash_hmac('sha256', $expectedPayload, 'super-secret'));
+        expect($signature)->not->toBe(hash_hmac('sha256', "{$timestamp}.", 'super-secret'));
+    });
 });
 
 describe('PassageHandler base class', function () {


### PR DESCRIPTION
## What was broken

`HasHmacAuth::resolveHmacSignedBody()` builds the HMAC-signed payload for `multipart/form-data` requests via `json_encode()` over the parsed fields and file metadata. `json_encode()` returns `false` whenever any field value contains bytes that are not valid UTF-8 (e.g. a client sending Latin-1/Windows-1252-encoded data, or any non-conforming input). Because the method has a non-nullable `: string` return type and the file has no `declare(strict_types=1)`, PHP's weak-type coercion silently converted that `false` into an empty string `''`.

The caller then computed the signature over `"$timestamp."` — the field content was dropped entirely, with no error, warning, or exception anywhere in the chain. This meant an attacker who could intercept or modify a multipart request containing a non-UTF-8 field could tamper with every other field's value in transit without invalidating `X-Signature`, defeating the integrity guarantee HMAC signing exists to provide. This is the same class of bug fixed for the "no files" multipart case in #121, reintroduced here through a narrower trigger (invalid UTF-8 bytes rather than plain-ASCII-only coverage gaps).

## What changed

- `resolveHmacSignedBody()` now passes `JSON_INVALID_UTF8_SUBSTITUTE` to `json_encode()`, so malformed byte sequences are replaced with the Unicode replacement character instead of aborting the whole encode. The signature now always covers the actual submitted field content.
- If `json_encode()` still fails for some other reason, the method now throws a `RuntimeException` instead of silently falling back to an empty-body signature.
- Added a regression test asserting that a multipart field containing invalid UTF-8 bytes produces a signature covering the actual field content, and explicitly asserting it does *not* match the degenerate "timestamp only" signature.

## Testing

- `vendor/bin/pint --dirty` — no changes needed.
- `composer test` — full suite passes (129 tests, 341 assertions).

Fixes #123


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXvqRfxFt1F2VBmxDuRUz6)_