### PR TITLE
Reject catch-all paths carrying their own scheme or authority

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -62,7 +62,7 @@ class PassageController extends Controller
             return response()->json(['error' => 'Route not found'], Response::HTTP_NOT_FOUND);
         }
 
-        if ($this->containsDotSegment($path)) {
+        if ($this->containsDotSegment($path) || $this->containsSchemeOrAuthority($path)) {
             return response()->json(['error' => 'Invalid path'], Response::HTTP_BAD_REQUEST);
         }
 
@@ -250,6 +250,36 @@ class PassageController extends Controller
                 if ($segment === '.' || $segment === '..') {
                     return true;
                 }
+            }
+
+            $previous = $decoded;
+            $decoded = rawurldecode($decoded);
+        } while ($decoded !== $previous);
+
+        return false;
+    }
+
+    /**
+     * Detect a path that would resolve to an absolute URI or one carrying
+     * its own authority. Guzzle's base_uri + relative-reference merge
+     * (RFC 3986 §5.3) discards the configured base_uri entirely once the
+     * reference has a scheme (e.g. "http://evil.example.com/x") or an
+     * authority (a leading "//", or a colon in the first path segment,
+     * which PSR-7's Uri parser also treats as introducing a scheme/host),
+     * letting a crafted path redirect the outbound request to an
+     * attacker-chosen host.
+     */
+    private function containsSchemeOrAuthority(string $path): bool
+    {
+        $decoded = $path;
+
+        do {
+            if (str_starts_with($decoded, '//')) {
+                return true;
+            }
+
+            if (str_contains(explode('/', $decoded, 2)[0], ':')) {
+                return true;
             }
 
             $previous = $decoded;

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -462,6 +462,32 @@ describe('PassageController', function () {
         'double-encoded parent segment' => '%252e%252e/private',
     ]);
 
+    it('rejects paths that would resolve to a URI with their own scheme or authority', function (string $path) {
+        $request = Request::create('/github/safe', 'GET');
+        $route = (new Route(['GET'], '/github/{path?}', []))
+            ->defaults('_passage_handler', TestPassageController::class)
+            ->where('path', '.*');
+        $route->bind($request);
+        $route->setParameter('path', $path);
+        $request->setRouteResolver(fn () => $route);
+
+        Http::shouldReceive('withOptions')->never();
+        $this->mockPassageService->shouldReceive('callService')->never();
+
+        $response = $this->controller->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_BAD_REQUEST);
+        expect($response->getData(true))->toBe(['error' => 'Invalid path']);
+    })->with([
+        'absolute URI with http scheme' => 'http://evil.example.com/x',
+        'absolute URI with https scheme' => 'https://evil.example.com/x',
+        'protocol-relative authority' => '//evil.example.com/x',
+        'scheme-like host:port without a leading slash' => 'evil.example.com:1337/x',
+        'percent-encoded scheme' => 'http%3A%2F%2Fevil.example.com/x',
+        'percent-encoded protocol-relative authority' => '%2F%2Fevil.example.com/x',
+        'double-encoded protocol-relative authority' => '%252F%252Fevil.example.com/x',
+    ]);
+
     it('applies response transformation', function () {
         $request = Request::create('/enriched/posts', 'GET');
         $route = (new Route(['GET'], '/enriched/{path?}', []))


### PR DESCRIPTION
## What was broken

The catch-all `{path}` route parameter is registered with `->where('path', '.*')`, so it can contain arbitrary characters. `PassageController::handle()` passed this raw, attacker-controlled path straight through to `PassageService::callService()`, which hands it to Guzzle as the request URI on a `PendingRequest` configured with the handler's `base_uri`.

Guzzle/PSR-7 URI resolution follows RFC 3986 §5.3: once the reference (the `{path}` value) has its own scheme or authority, the base URI is discarded entirely and the reference is used verbatim. This meant a request like `GET /github/http://evil.internal/steal` would be sent to `evil.internal`, not the handler's configured `api.example.com` — completely bypassing `enforce_allowed_hosts`, since `AllowedHostsGuard` only ever validated the *configured* `base_uri`, never the actual resolved outbound target. Any credentials a handler's auth trait (`HasBearerAuth`, `HasApiKeyAuth`, `HasHmacAuth`) injected into the request were sent straight to the attacker-chosen host.

This wasn't limited to obvious `scheme://` prefixes — a path like `evil.internal:1337/steal` (no `//` at all) also hijacks the host, because PSR-7's URI parser treats a colon in the first path segment as introducing a scheme/authority too.

## What changed

- Added `PassageController::containsSchemeOrAuthority()`, which rejects any `{path}` value that would resolve to a URI carrying its own scheme or authority — a leading `//` (protocol-relative), or a colon in the first path segment (covers `scheme://host`, `//host`, and bare `host:port` forms) — including percent-encoded and double-encoded variants, mirroring the existing `containsDotSegment()` guard.
- Wired this check into `PassageController::handle()` alongside the dot-segment check, returning the same `400 Invalid path` response.
- Added regression tests covering absolute URIs (`http://`, `https://`), protocol-relative paths (`//`), scheme-like `host:port` paths, and their percent-encoded/double-encoded forms.

Fixes #128


---
_Generated by [Claude Code](https://claude.ai/code/session_0127KenNr9ZUur9FNKMou5wd)_