### PR TITLE
Fix backslash-normalization gap in dot-segment traversal guard

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -253,7 +253,7 @@ class PassageController extends Controller
             }
 
             $previous = $decoded;
-            $decoded = rawurldecode($decoded);
+            $decoded = str_replace('\\', '/', rawurldecode($decoded));
         } while ($decoded !== $previous);
 
         return false;

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -460,6 +460,8 @@ describe('PassageController', function () {
         'mixed-encoded parent segment' => '%2E./private',
         'encoded separator after parent segment' => '%2e%2e%2fprivate',
         'double-encoded parent segment' => '%252e%252e/private',
+        'percent-encoded backslash separator' => '..%5c..%5cetc%5cpasswd',
+        'mixed literal and percent-encoded backslash separator' => '%2e%2e%5cprivate',
     ]);
 
     it('rejects paths that would resolve to a URI with their own scheme or authority', function (string $path) {


### PR DESCRIPTION
## What was broken

`PassageController::containsDotSegment()` guards against path-traversal segments (`.`/`..`) in the catch-all proxied path, decoding percent-encoded input in a loop until it stabilizes. Backslashes are normalized to `/` only once, **before** the decode loop starts.

A backslash that only appears after a `rawurldecode()` pass — i.e. one submitted as `%5c` — was never converted to `/`, so it never became its own path segment for the `.`/`..` check. For example, `..%5c..%5cetc%5cpasswd` decodes to `..\..\etc\passwd`, but since the backslash normalization wasn't re-applied after decoding, `explode('/', ...)` saw one segment with no separators and the traversal was never detected — bypassing the guard entirely.

## What changed

- `src/Http/Controllers/PassageController.php`: re-apply `str_replace('\\', '/', ...)` after every `rawurldecode()` iteration in `containsDotSegment()`, not just once before the loop, so backslashes introduced by decoding are normalized before the next segment check.
- `tests/Unit/PassageControllerTest.php`: added regression cases for `..%5c..%5cetc%5cpasswd` and `%2e%2e%5cprivate`, which reproduce the bypass on the old code (verified they return a 500 instead of the expected 400 without the fix) and now correctly return `400 Invalid path`.

Fixes #129


---
_Generated by [Claude Code](https://claude.ai/code/session_01BZPQkA5PV1QM3JC3UrEAHj)_