### PR TITLE
docs: fix withRetry when-callback type hint in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,13 +406,13 @@ class PaymentsHandler extends PassageHandler
 php artisan passage:controller PaymentsHandler --with-retry
 ```
 
-`withRetry($times, $sleepMs, ?callable $when)` accepts an optional third argument — a callable that receives the exception and response and returns `true` if the request should be retried:
+`withRetry($times, $sleepMs, ?callable $when)` accepts an optional third argument — a callable that receives the exception and the pending request and returns `true` if the request should be retried:
 
 ```php
 $this->withRetry(
     times: 3,
     sleepMs: 200,
-    when: function (\Exception $e, \Illuminate\Http\Client\Response $response) {
+    when: function (\Exception $e, \Illuminate\Http\Client\PendingRequest $request) {
         // Only retry on connection errors, not on 4xx responses
         return $e instanceof \Illuminate\Http\Client\ConnectionException;
     }


### PR DESCRIPTION
Closes #142.

The `when` callback in the Retry section type-hinted its second parameter as `\Illuminate\Http\Client\Response`, but Laravel's `PendingRequest::retry()` calls it with the `PendingRequest` instance, so copying the example verbatim throws a `TypeError` on the first retryable failure. This updates the hint (and the surrounding prose and parameter name) to `PendingRequest $request`, matching the existing docblock in `HasResilienceOptions`. README-only.