### PR TITLE
fix: bind HMAC signature to HTTP method, path, and query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ public function getRequest(Request $request): Request
 }
 ```
 
-This signs the request body and a timestamp using HMAC-SHA256 and adds `X-Timestamp` and `X-Signature` headers to the outgoing request.
+This signs the timestamp, HTTP method, path, query string, and request body using HMAC-SHA256 and adds `X-Timestamp` and `X-Signature` headers to the outgoing request.
 
 ```bash
 php artisan passage:controller PartnerHandler --with-auth=hmac

--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -11,10 +11,16 @@ trait HasHmacAuth
     /**
      * Sign the outbound request with an HMAC signature.
      *
-     * The signature is computed over: timestamp + "." + request body.
+     * The signature is computed over: timestamp + "." + method + "." + path
+     * + "." + query string + "." + request body. Binding the method, path,
+     * and query string (in addition to the body) prevents an intermediary
+     * from rewriting the request target without invalidating the signature
+     * — this matters most for GET/HEAD requests, which have no body and
+     * would otherwise carry no real signature at all.
+     *
      * Two headers are added to the request:
      *   X-Timestamp  — Unix timestamp used in the signature (replay protection)
-     *   X-Signature  — HMAC hex digest: hash_hmac($algorithm, "$timestamp.$body", $secret)
+     *   X-Signature  — HMAC hex digest of the payload described above
      *
      * The header names and algorithm are configurable.
      *
@@ -30,13 +36,31 @@ trait HasHmacAuth
     ): Request {
         $timestamp = (string) time();
         $body = $this->resolveHmacSignedBody($request);
-        $payload = $timestamp.'.'.$body;
+        $payload = implode('.', [
+            $timestamp,
+            $request->getMethod(),
+            $request->getPathInfo(),
+            $this->resolveHmacSignedQuery($request),
+            $body,
+        ]);
         $signature = hash_hmac($algorithm, $payload, $secret);
 
         $request->headers->set($timestampHeader, $timestamp);
         $request->headers->set($signatureHeader, $signature);
 
         return $request;
+    }
+
+    /**
+     * Resolve a canonical (key-sorted) query string so that reordering query
+     * parameters cannot change the signed payload.
+     */
+    private function resolveHmacSignedQuery(Request $request): string
+    {
+        $query = $request->query();
+        ksort($query);
+
+        return http_build_query($query);
     }
 
     /**

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -170,7 +170,7 @@ describe('HasHmacAuth', function () {
 
         $timestamp = $result->header('X-Timestamp');
         $signature = $result->header('X-Signature');
-        $expected = hash_hmac('sha256', $timestamp.'.'.$body, 'super-secret');
+        $expected = hash_hmac('sha256', $timestamp.'.POST./test..'.$body, 'super-secret');
 
         expect($signature)->toBe($expected);
     });
@@ -185,8 +185,64 @@ describe('HasHmacAuth', function () {
         expect($result->header('X-Req-Sig'))->not->toBeEmpty();
 
         $timestamp = $result->header('X-Req-Time');
-        $expected = hash_hmac('sha512', $timestamp.'.', 'super-secret');
+        $expected = hash_hmac('sha512', $timestamp.'.POST./test..', 'super-secret');
         expect($result->header('X-Req-Sig'))->toBe($expected);
+    });
+
+    it('binds the signature to the HTTP method and path', function () {
+        $handler = new HmacHandler;
+
+        $getRequest = Request::create('/accounts/42/balance', 'GET');
+        $postRequest = Request::create('/accounts/42/balance', 'POST');
+
+        $getResult = $handler->getRequest($getRequest);
+        $postResult = $handler->getRequest($postRequest);
+
+        expect($getResult->header('X-Signature'))->not->toBe($postResult->header('X-Signature'));
+    });
+
+    it('produces a non-trivial signature for a bodyless GET request', function () {
+        $handler = new HmacHandler;
+        $request = Request::create('/accounts/42/balance', 'GET');
+
+        $result = $handler->getRequest($request);
+
+        $timestamp = $result->header('X-Timestamp');
+        $signature = $result->header('X-Signature');
+        $expected = hash_hmac('sha256', $timestamp.'.GET./accounts/42/balance..', 'super-secret');
+
+        expect($signature)->toBe($expected);
+        expect($signature)->not->toBe(hash_hmac('sha256', "{$timestamp}.", 'super-secret'));
+    });
+
+    it('binds the signature to the query string', function () {
+        $handler = new HmacHandler;
+
+        $requestA = Request::create('/accounts/42/balance?currency=USD', 'GET');
+        $requestB = Request::create('/accounts/42/balance?currency=EUR', 'GET');
+
+        $resultA = $handler->getRequest($requestA);
+        $resultB = $handler->getRequest($requestB);
+
+        expect($resultA->header('X-Signature'))->not->toBe($resultB->header('X-Signature'));
+    });
+
+    it('canonicalizes the query string so parameter order does not change the signature', function () {
+        $handler = new HmacHandler;
+
+        $requestA = Request::create('/search?b=2&a=1', 'GET');
+        $requestB = Request::create('/search?a=1&b=2', 'GET');
+
+        $resultA = $handler->getRequest($requestA);
+        $resultB = $handler->getRequest($requestB);
+
+        $timestampA = $resultA->header('X-Timestamp');
+        $expected = hash_hmac('sha256', $timestampA.'.GET./search.a=1&b=2.', 'super-secret');
+
+        expect($resultA->header('X-Signature'))->toBe($expected);
+        expect($resultA->header('X-Signature'))->toBe(
+            hash_hmac('sha256', $resultB->header('X-Timestamp').'.GET./search.a=1&b=2.', 'super-secret')
+        );
     });
 
     it('signs the parsed fields of a multipart request instead of the empty raw body', function () {
@@ -202,7 +258,7 @@ describe('HasHmacAuth', function () {
 
         $timestamp = $result->header('X-Timestamp');
         $signature = $result->header('X-Signature');
-        $expectedPayload = $timestamp.'.'.json_encode([
+        $expectedPayload = $timestamp.'.POST./test..'.json_encode([
             'fields' => ['field1' => 'hello', 'field2' => 'world'],
             'files' => [],
         ]);
@@ -224,11 +280,11 @@ describe('HasHmacAuth', function () {
         $resultA = $handlerA->getRequest($requestA);
         $resultB = $handlerB->getRequest($requestB);
 
-        $expectedA = hash_hmac('sha256', $resultA->header('X-Timestamp').'.'.json_encode([
+        $expectedA = hash_hmac('sha256', $resultA->header('X-Timestamp').'.POST./test..'.json_encode([
             'fields' => ['field1' => 'hello'],
             'files' => [],
         ]), 'super-secret');
-        $expectedB = hash_hmac('sha256', $resultB->header('X-Timestamp').'.'.json_encode([
+        $expectedB = hash_hmac('sha256', $resultB->header('X-Timestamp').'.POST./test..'.json_encode([
             'fields' => ['field1' => 'goodbye'],
             'files' => [],
         ]), 'super-secret');
@@ -250,7 +306,7 @@ describe('HasHmacAuth', function () {
 
         $timestamp = $result->header('X-Timestamp');
         $signature = $result->header('X-Signature');
-        $expectedPayload = $timestamp.'.'.json_encode([
+        $expectedPayload = $timestamp.'.POST./test..'.json_encode([
             'fields' => ['comment' => $invalid],
             'files' => [],
         ], JSON_INVALID_UTF8_SUBSTITUTE);


### PR DESCRIPTION
## What was broken

`HasHmacAuth::withHmacSignature()` computed the signed payload as just `timestamp + "." + body`. The HTTP method, request path, and query string were never part of the signature.

Two concrete consequences:

1. **GET/HEAD requests carried no real signature.** These requests have no body, so the "signature" reduced to `hash_hmac($algorithm, "$timestamp.", $secret)` — a value that depends on nothing but the timestamp. It authenticated neither the path nor any query parameters.
2. **Path/query tampering was invisible to the signature for every method.** An intermediary could rewrite the URL path or query string of a signed request without invalidating `X-Signature`, since neither was part of the hashed payload.

This undermined the trait's own purpose: proving to an upstream partner API that a request came from Passage unmodified.

## What changed

- `withHmacSignature()` now signs `timestamp + "." + method + "." + path + "." + query string + "." + body`, so the HTTP method, path, and query string are bound to the signature.
- The query string is canonicalized (key-sorted) before signing, so reordering query parameters doesn't change the signed payload or falsely appear tampered.
- Updated the docblock and README's HMAC signing section to describe the new payload format.
- Updated existing tests to the new payload format and added regression tests asserting: the signature changes with method/path, a bodyless GET still produces a non-trivial signature bound to its path, the signature changes with the query string, and query parameter reordering does not change the signature.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (142 tests, 383 assertions)

Fixes #137


---
_Generated by [Claude Code](https://claude.ai/code/session_01RMkNQP9QzCS7P386h6oBfs)_