### PR TITLE
fix: include file content hash in HMAC signature for multipart requests

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -68,8 +68,9 @@ trait HasHmacAuth
      *
      * PHP consumes php://input while populating $_POST/$_FILES for
      * multipart/form-data requests, so getContent() is always empty for
-     * them. Sign a stable representation of the parsed fields and file
-     * metadata instead, so the signature still covers what was submitted.
+     * them. Sign a stable representation of the parsed fields and, for each
+     * uploaded file, its metadata plus a content hash — so a swapped file
+     * body invalidates the signature even when name/size/mime are unchanged.
      */
     private function resolveHmacSignedBody(Request $request): string
     {
@@ -85,6 +86,7 @@ trait HasHmacAuth
                     'name' => $singleFile->getClientOriginalName(),
                     'size' => $singleFile->getSize(),
                     'mime' => $singleFile->getMimeType(),
+                    'hash' => hash('sha256', $singleFile->get()),
                 ];
             }
         }

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\PassageHandler;
 
@@ -313,6 +314,29 @@ describe('HasHmacAuth', function () {
 
         expect($signature)->toBe(hash_hmac('sha256', $expectedPayload, 'super-secret'));
         expect($signature)->not->toBe(hash_hmac('sha256', "{$timestamp}.", 'super-secret'));
+    });
+
+    it('produces different signatures for uploaded files with identical metadata but different content', function () {
+        $handlerA = new HmacHandler;
+        $handlerB = new HmacHandler;
+
+        $fileA = UploadedFile::fake()->createWithContent('avatar.png', str_repeat('A', 16));
+        $fileB = UploadedFile::fake()->createWithContent('avatar.png', str_repeat('B', 16));
+
+        $requestA = Request::create('/test', 'POST', [], [], ['avatar' => $fileA], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+        $requestB = Request::create('/test', 'POST', [], [], ['avatar' => $fileB], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+
+        $resultA = $handlerA->getRequest($requestA);
+        $resultB = $handlerB->getRequest($requestB);
+
+        expect($fileA->getClientOriginalName())->toBe($fileB->getClientOriginalName());
+        expect($fileA->getSize())->toBe($fileB->getSize());
+        expect($fileA->getMimeType())->toBe($fileB->getMimeType());
+        expect($resultA->header('X-Signature'))->not->toBe($resultB->header('X-Signature'));
     });
 });
 


### PR DESCRIPTION
## What was broken

`HasHmacAuth::resolveHmacSignedBody()` signs a stable representation of the parsed fields and file metadata for `multipart/form-data` requests, since PHP consumes `php://input` before userland code runs. For each uploaded file, only `name`, `size`, and `mime` were included in the signed payload — the actual file bytes were never hashed or otherwise represented.

This meant two uploads with identical filename/size/mime metadata but completely different byte content produced an **identical** HMAC signature. `HasHmacAuth` exists to give the upstream service an integrity guarantee over what Passage forwards, so an intermediary (or a bug elsewhere in the pipeline) that swapped a file's content while preserving its name/size/mime would produce a request the upstream verifies as authentic, even though the payload was altered.

## What changed

- `src/Concerns/HasHmacAuth.php`: `resolveHmacSignedBody()` now includes a SHA-256 hash of each uploaded file's content (`hash('sha256', $singleFile->get())`) alongside its existing metadata in the signed payload, so any change to the file bytes changes the signature. Updated the method's docblock to reflect this.
- `tests/Unit/AuthTraitsTest.php`: added a regression test asserting that two multipart requests with identical file metadata (name/size/mime) but different file content produce different `X-Signature` values.

## Testing

- `vendor/bin/pest` — full suite passes (143 tests, 387 assertions).
- `vendor/bin/pint --dirty` — no formatting changes required.

Fixes #130

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH52SeGQRYzWkeDCvH5ih1)_