### PR TITLE
fix: bind HMAC signature to the path actually forwarded upstream

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -39,7 +39,7 @@ trait HasHmacAuth
         $payload = implode('.', [
             $timestamp,
             $request->getMethod(),
-            $request->getPathInfo(),
+            $this->resolveHmacSignedPath($request),
             $this->resolveHmacSignedQuery($request),
             $body,
         ]);
@@ -49,6 +49,26 @@ trait HasHmacAuth
         $request->headers->set($signatureHeader, $signature);
 
         return $request;
+    }
+
+    /**
+     * Resolve the path to bind into the signature.
+     *
+     * PassageController forwards $request->route('path', '') to Guzzle as
+     * the upstream request target (see PassageController::handle()), which
+     * is only the wildcard remainder of the matched route — not the full
+     * inbound URI (any literal prefix segments of the route definition,
+     * e.g. Passage::post('accounts/{path?}', ...), are stripped). Signing
+     * getPathInfo() would bind the signature to a string the upstream never
+     * actually receives, so mirror the same route parameter here. Fall back
+     * to getPathInfo() when no route is bound (e.g. calling getRequest()
+     * directly, outside of route dispatch).
+     */
+    private function resolveHmacSignedPath(Request $request): string
+    {
+        return $request->route() !== null
+            ? (string) $request->route('path', '')
+            : $request->getPathInfo();
     }
 
     /**

--- a/tests/Feature/PassageIntegrationTest.php
+++ b/tests/Feature/PassageIntegrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 use Morcen\Passage\Contracts\AcceptsClientHeaders;
@@ -80,6 +81,19 @@ class NoBaseUriHandler extends PassageHandler
     public function getOptions(): array
     {
         return [];
+    }
+}
+
+class HmacIntegrationHandler extends PassageHandler
+{
+    public function getRequest(Request $request): Request
+    {
+        return $this->withHmacSignature($request, 'partner-secret');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://partner.example.com/'];
     }
 }
 
@@ -231,6 +245,27 @@ describe('Passage Integration Tests', function () {
             $response = $this->get('/redirect-ok/entry');
 
             $response->assertStatus(200)->assertJson(['ok' => true]);
+        });
+    });
+
+    describe('HasHmacAuth path binding', function () {
+        it('signs the path actually forwarded upstream, not the full inbound route path', function () {
+            Http::fake(['https://partner.example.com/*' => Http::response(['ok' => true], 200)]);
+            Passage::post('accounts/{path?}', HmacIntegrationHandler::class);
+
+            $this->postJson('/accounts/42/balance', [])->assertStatus(200);
+
+            Http::assertSent(function ($req) {
+                $timestamp = $req->header('X-Timestamp')[0];
+                $expected = hash_hmac(
+                    'sha256',
+                    implode('.', [$timestamp, 'POST', '42/balance', '', $req->body()]),
+                    'partner-secret'
+                );
+
+                return $req->url() === 'https://partner.example.com/42/balance'
+                    && $req->header('X-Signature')[0] === $expected;
+            });
         });
     });
 


### PR DESCRIPTION
## What was broken

`HasHmacAuth::withHmacSignature()` signed `$request->getPathInfo()` — the full inbound request path — while `PassageService` only ever forwards the matched route's wildcard `path` parameter to the upstream service (`PassageController::handle()` resolves `$path = (string) $request->route('path', '')` and passes that to Guzzle, not the full inbound URI).

For any handler using the documented pattern, e.g.:

```php
Passage::post('accounts/{path?}', AccountsHandler::class);
```

a client request to `POST /accounts/42/balance` would sign the path `/accounts/42/balance`, but Passage would actually forward the request to `42/balance` relative to the handler's `base_uri`. These two values never match, so any upstream service that verifies the signature against the request-target it actually receives (the documented purpose of binding the path into the signature — to prevent an intermediary from rewriting the request target) would always reject the request. The path-binding guarantee was effectively non-functional for real deployments.

## What changed

- `src/Concerns/HasHmacAuth.php`: added `resolveHmacSignedPath()`, which signs the same route `path` parameter that `PassageController` forwards to Guzzle, falling back to `getPathInfo()` only when no route is bound (e.g. calling `getRequest()` directly outside of route dispatch, as the existing unit tests do).
- `tests/Feature/PassageIntegrationTest.php`: added a full route-dispatch regression test asserting the signed path matches the sub-path actually forwarded to the upstream service, not the full inbound route path.

## Test plan

- [x] `vendor/bin/pint --dirty` — no changes needed
- [x] `composer test` — full suite passes (145 passed, 391 assertions)

Fixes #163


---
_Generated by [Claude Code](https://claude.ai/code/session_011PECPQURyHxcjRiqr2zpxe)_