### PR TITLE
Strip stale Content-Encoding/Content-Length headers on proxied responses

### DIFF
--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -15,6 +15,13 @@ class PassageResponseBuilder
         'proxy-authorization',
     ];
 
+    // Guzzle's default `decode_content` option transparently decompresses gzip/deflate/br
+    // bodies (Passage never disables it), but leaves Content-Encoding/Content-Length on the
+    // response describing the discarded compressed representation. Relaying them verbatim
+    // alongside the already-decoded body corrupts the response for every compressing
+    // upstream, so they must always be stripped rather than passed through.
+    private const STALE_CONTENT_HEADERS = ['content-encoding', 'content-length'];
+
     public function build(Response $upstream): SymfonyResponse
     {
         $status = $upstream->status();
@@ -74,7 +81,9 @@ class PassageResponseBuilder
         $headers = [];
 
         foreach ($upstream->headers() as $name => $values) {
-            if (in_array(strtolower($name), $hopByHop, strict: true)) {
+            $lowerName = strtolower($name);
+
+            if (in_array($lowerName, $hopByHop, strict: true) || in_array($lowerName, self::STALE_CONTENT_HEADERS, strict: true)) {
                 continue;
             }
             $headers[$name] = is_array($values) ? implode(', ', $values) : $values;

--- a/tests/Unit/PassageResponseBuilderTest.php
+++ b/tests/Unit/PassageResponseBuilderTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\JsonResponse;
 use Morcen\Passage\Http\PassageResponseBuilder;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 beforeEach(function () {
     $this->builder = new PassageResponseBuilder;
@@ -143,5 +146,63 @@ describe('PassageResponseBuilder::build()', function () {
             expect($response->headers->has('proxy-authorization'))->toBeFalse();
             expect($response->headers->get('x-custom'))->toBe('pass-through');
         });
+    });
+
+    describe('stale Content-Encoding/Content-Length headers', function () {
+        it('strips Content-Encoding and Content-Length since Guzzle already decoded the body', function () {
+            // Guzzle's default decode_content transparently gunzips the body but leaves
+            // Content-Encoding/Content-Length describing the discarded compressed bytes.
+            $upstream = upstreamMock(
+                'plain decoded body',
+                200,
+                'text/plain',
+                ['content-encoding' => ['gzip'], 'content-length' => ['36'], 'x-custom' => ['pass-through']]
+            );
+
+            $response = $this->builder->build($upstream);
+
+            expect($response->headers->has('content-encoding'))->toBeFalse();
+            expect($response->headers->has('content-length'))->toBeFalse();
+            expect($response->headers->get('x-custom'))->toBe('pass-through');
+            expect($response->getContent())->toBe('plain decoded body');
+        });
+
+        it('strips Content-Encoding and Content-Length on JSON responses too', function () {
+            $upstream = upstreamMock(
+                '{"ok":true}',
+                200,
+                'application/json',
+                ['content-encoding' => ['deflate'], 'content-length' => ['10']]
+            );
+
+            $response = $this->builder->build($upstream);
+
+            expect($response->headers->has('content-encoding'))->toBeFalse();
+            expect($response->headers->has('content-length'))->toBeFalse();
+        });
+    });
+});
+
+describe('PassageResponseBuilder::buildStreamedResponse()', function () {
+    it('strips Content-Encoding and Content-Length from the streamed response', function () {
+        $upstream = Mockery::mock(Response::class);
+        $upstream->shouldReceive('status')->andReturn(200);
+        $upstream->shouldReceive('headers')->andReturn([
+            'content-type' => ['text/event-stream'],
+            'content-encoding' => ['gzip'],
+            'content-length' => ['36'],
+            'x-custom' => ['pass-through'],
+        ]);
+
+        $stream = Utils::streamFor('data: hello');
+        $psr7 = new Psr7Response(200, [], $stream);
+        $upstream->shouldReceive('toPsrResponse')->andReturn($psr7);
+
+        $response = $this->builder->buildStreamedResponse($upstream);
+
+        expect($response)->toBeInstanceOf(StreamedResponse::class);
+        expect($response->headers->has('content-encoding'))->toBeFalse();
+        expect($response->headers->has('content-length'))->toBeFalse();
+        expect($response->headers->get('x-custom'))->toBe('pass-through');
     });
 });


### PR DESCRIPTION
## What was broken

`PassageResponseBuilder::build()` and `buildStreamedResponse()` relayed every upstream response header verbatim (minus a small hop-by-hop list), including `Content-Encoding` and `Content-Length`.

Guzzle's `decode_content` option defaults to `true` (Passage never overrides it), so on the curl handler this transparently decompresses `gzip`/`deflate`/`br` upstream bodies at the transport layer. curl does **not** rewrite or strip the `Content-Encoding`/`Content-Length` headers it reports back — those still describe the original, now-stale *compressed* representation.

The result: for any upstream that compresses its responses (extremely common), Passage relayed an already-decoded plaintext body alongside headers claiming it was still compressed with the compressed byte count. Downstream clients would then try to gunzip already-decoded bytes and fail, or truncate/hang reading a body longer than the stale `Content-Length`. This affected every response from a compressing upstream, silently, with no error anywhere in the chain.

## What changed

- `PassageResponseBuilder::resolveResponseHeaders()` now also strips `Content-Encoding` and `Content-Length` from the relayed headers, since the body it forwards is always the already-decoded one.
- This fixes both the buffered path (`build()`) and the streamed path (`buildStreamedResponse()`), since both route through `resolveResponseHeaders()`.
- Added regression tests in `tests/Unit/PassageResponseBuilderTest.php` covering plain, JSON, and streamed responses with a stale `Content-Encoding`/`Content-Length` from the upstream.

Fixes #125

## Test plan

- `vendor/bin/pint --dirty` — passed
- `composer test` (`vendor/bin/pest`) — 148 passed, including the new regression tests


---
_Generated by [Claude Code](https://claude.ai/code/session_015kn9YKR8Yt4MmjTdbqtp4Z)_