### PR TITLE
Fix case-sensitive multipart Content-Type check in HMAC signing

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -94,7 +94,7 @@ trait HasHmacAuth
      */
     private function resolveHmacSignedBody(Request $request): string
     {
-        if (! str_contains($request->header('Content-Type', ''), 'multipart/form-data')) {
+        if (! str_contains(strtolower($request->header('Content-Type', '')), 'multipart/form-data')) {
             return $request->getContent();
         }
 

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -338,6 +338,25 @@ describe('HasHmacAuth', function () {
         expect($fileA->getMimeType())->toBe($fileB->getMimeType());
         expect($resultA->header('X-Signature'))->not->toBe($resultB->header('X-Signature'));
     });
+
+    it('detects multipart requests regardless of Content-Type casing', function () {
+        $handler = new HmacHandler;
+
+        $request = Request::create('/test', 'POST', ['field1' => 'hello'], [], [], [
+            'CONTENT_TYPE' => 'MULTIPART/FORM-DATA; boundary=----boundary',
+        ], '');
+
+        $result = $handler->getRequest($request);
+
+        $timestamp = $result->header('X-Timestamp');
+        $signature = $result->header('X-Signature');
+        $expectedPayload = $timestamp.'.POST./test..'.json_encode([
+            'fields' => ['field1' => 'hello'],
+            'files' => [],
+        ]);
+
+        expect($signature)->toBe(hash_hmac('sha256', $expectedPayload, 'super-secret'));
+    });
 });
 
 describe('PassageHandler base class', function () {


### PR DESCRIPTION
## What was broken

`HasHmacAuth::resolveHmacSignedBody()` detected multipart requests with a case-sensitive check:

```php
str_contains($request->header('Content-Type', ''), 'multipart/form-data')
```

(`src/Concerns/HasHmacAuth.php:97`)

HTTP media types are case-insensitive per RFC 9110, and PHP populates `$_POST`/`$_FILES` regardless of the exact casing of the `Content-Type` header. A request sent with `Content-Type: MULTIPART/FORM-DATA; boundary=...` (or any other non-canonical casing) is correctly parsed by PHP, but the exact-case `str_contains()` check returned `false` for it. In that case `resolveHmacSignedBody()` fell through to `$request->getContent()`, which is empty for multipart requests (PHP consumes `php://input` while parsing the body). The HMAC signature ended up covering only `timestamp.method.path.query.` — no binding to the submitted fields or files at all.

This silently reopened the vulnerability that PRs #121 and #156 were written to close: a client sending a non-canonical-case Content-Type could submit arbitrary multipart fields/files under a signature that didn't actually cover them, defeating the integrity guarantee `HasHmacAuth` is meant to provide.

## What changed

- `src/Concerns/HasHmacAuth.php`: compare the `Content-Type` header case-insensitively (`strtolower(...)`) when detecting multipart requests.
- `tests/Unit/AuthTraitsTest.php`: added a regression test that sends a multipart request with an upper-case `Content-Type` and asserts the signature still binds to the submitted fields.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` (full suite) — 149 passed, 402 assertions

Fixes #171
