### PR TITLE
Stop leaking internal handler class names and hostnames in error responses

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -76,9 +76,13 @@ class PassageController extends Controller
 
             $this->allowedHostsGuard->check($mergedOptions['base_uri']);
         } catch (InvalidBaseUriException $e) {
-            return response()->json(['error' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR);
+            $this->fireEvent(new PassageRequestFailed($request, $handler, $e, 0.0));
+
+            return response()->json(['error' => 'Upstream configuration error.'], Response::HTTP_INTERNAL_SERVER_ERROR);
         } catch (DisallowedProxyTargetException $e) {
-            return response()->json(['error' => $e->getMessage()], Response::HTTP_FORBIDDEN);
+            $this->fireEvent(new PassageRequestFailed($request, $handler, $e, 0.0));
+
+            return response()->json(['error' => 'Upstream host is not permitted.'], Response::HTTP_FORBIDDEN);
         }
 
         // Extract Passage reserved keys before passing options to Guzzle.
@@ -159,7 +163,7 @@ class PassageController extends Controller
             $durationMs = (microtime(true) - $startedAt) * 1000;
             $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));
 
-            return response()->json(['error' => $e->getMessage()], Response::HTTP_FORBIDDEN);
+            return response()->json(['error' => 'Upstream host is not permitted.'], Response::HTTP_FORBIDDEN);
         } catch (ConnectionException|Throwable $e) {
             $durationMs = (microtime(true) - $startedAt) * 1000;
             $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));

--- a/tests/Feature/PassageIntegrationTest.php
+++ b/tests/Feature/PassageIntegrationTest.php
@@ -301,7 +301,7 @@ describe('Passage Integration Tests', function () {
                 ->get('/missing-base-uri/resource')
                 ->assertStatus(500)
                 ->assertJson([
-                    'error' => "Passage handler [NoBaseUriHandler] must return a 'base_uri' from getOptions().",
+                    'error' => 'Upstream configuration error.',
                 ]);
         });
 

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -4,7 +4,9 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Morcen\Passage\Events\PassageRequestFailed;
 use Morcen\Passage\Exceptions\DisallowedProxyTargetException;
 use Morcen\Passage\Exceptions\PassageRequestAbortedException;
 use Morcen\Passage\Guards\AllowedHostsGuard;
@@ -224,11 +226,27 @@ describe('PassageController', function () {
 
         expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
         expect(json_decode($response->getContent(), true))->toBe([
-            'error' => sprintf(
-                'Passage handler [%s] must return a \'base_uri\' from getOptions().',
-                TestNoBaseUriPassageController::class
-            ),
+            'error' => 'Upstream configuration error.',
         ]);
+    });
+
+    it('does not leak the handler class name to the client but still reports it via PassageRequestFailed', function () {
+        Event::fake([PassageRequestFailed::class]);
+
+        $request = Request::create('/no-base-uri/test', 'GET');
+        $route = (new Route(['GET'], '/no-base-uri/{path?}', []))
+            ->defaults('_passage_handler', TestNoBaseUriPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        $response = $this->controller->handle($request);
+
+        expect(json_decode($response->getContent(), true)['error'])->not->toContain(TestNoBaseUriPassageController::class);
+
+        Event::assertDispatched(PassageRequestFailed::class, function (PassageRequestFailed $event) {
+            return $event->handler === TestNoBaseUriPassageController::class
+                && str_contains($event->exception->getMessage(), TestNoBaseUriPassageController::class);
+        });
     });
 
     it('returns a JSON 403 when the base_uri host is not in the allowed_hosts list', function () {
@@ -249,8 +267,33 @@ describe('PassageController', function () {
 
         expect($response->getStatusCode())->toBe(ResponseCode::HTTP_FORBIDDEN);
         expect(json_decode($response->getContent(), true))->toBe([
-            'error' => 'Upstream host [api.evil.com] is not in the passage allowed_hosts list.',
+            'error' => 'Upstream host is not permitted.',
         ]);
+    });
+
+    it('does not leak the upstream hostname to the client but still reports it via PassageRequestFailed', function () {
+        Event::fake([PassageRequestFailed::class]);
+
+        config([
+            'passage.security.enforce_allowed_hosts' => true,
+            'passage.security.allowed_hosts' => ['api.example.com'],
+        ]);
+
+        $request = Request::create('/blocked-host/test', 'GET');
+        $route = (new Route(['GET'], '/blocked-host/{path?}', []))
+            ->defaults('_passage_handler', TestDisallowedHostPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        Http::shouldReceive('withOptions')->never();
+
+        $response = $this->controller->handle($request);
+
+        expect(json_decode($response->getContent(), true)['error'])->not->toContain('api.evil.com');
+
+        Event::assertDispatched(PassageRequestFailed::class, function (PassageRequestFailed $event) {
+            return str_contains($event->exception->getMessage(), 'api.evil.com');
+        });
     });
 
     it('returns a JSON 403 when an upstream redirect targets a host outside allowed_hosts', function () {
@@ -279,7 +322,7 @@ describe('PassageController', function () {
 
         expect($response->getStatusCode())->toBe(ResponseCode::HTTP_FORBIDDEN);
         expect(json_decode($response->getContent(), true))->toBe([
-            'error' => 'Upstream host [evil.example.com] is not in the passage allowed_hosts list.',
+            'error' => 'Upstream host is not permitted.',
         ]);
     });
 


### PR DESCRIPTION
## What was broken

Two error paths in `PassageController::handle()` returned exception messages verbatim as the client-facing `error` field in the JSON response:

- `InvalidBaseUriException` (thrown when a handler's `getOptions()` omits `base_uri`) embedded the app's fully-qualified handler class name.
- `DisallowedProxyTargetException` (thrown by `AllowedHostsGuard` on the initial `base_uri` check and on redirect-hop revalidation) embedded the real upstream/redirect-target hostname.

Both were caught and passed straight through to the external API caller. Passage's stated purpose is to hide upstream API structure from consumers, so returning internal namespace/class layout and infrastructure hostnames to any caller who triggers a misconfiguration or a redirect-guard rejection is an avoidable information disclosure.

## What changed

- `PassageController::handle()` now returns generic client-facing messages instead of the raw exception text:
  - `InvalidBaseUriException` → `"Upstream configuration error."` (500)
  - `DisallowedProxyTargetException` → `"Upstream host is not permitted."` (403), in both the initial `base_uri` check and the redirect-guard rejection path.
- The detailed exception (with the handler class name / real hostname) is still available server-side: the initial `base_uri`/host check now fires the existing `PassageRequestFailed` event (previously only fired for transport-level failures), so operators with the optional `PassageEventSubscriber` registered retain full diagnostic detail without exposing it to clients.
- Updated existing unit/feature tests to assert on the new generic messages, and added regression tests asserting the client response never contains the handler class name or hostname while `PassageRequestFailed` still carries the detailed message.

Fixes #176