### PR TITLE
fix: forward multipart/form-data fields when a request has no files

### DIFF
--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -30,7 +30,15 @@ class PassageService implements PassageServiceInterface
             return $this->dispatch($service, $method, $uri);
         }
 
-        if (count($request->allFiles()) > 0) {
+        $contentType = $request->header('Content-Type', '');
+
+        // PHP consumes php://input while populating $_POST/$_FILES for
+        // multipart/form-data requests, so getContent() is always empty for
+        // them — even when the request has no file fields, only text ones.
+        // Detect the content type directly rather than relying on
+        // allFiles() being non-empty, so plain multipart forms aren't
+        // dropped into the raw-passthrough branch below with no body.
+        if (count($request->allFiles()) > 0 || str_contains(strtolower($contentType), 'multipart/form-data')) {
             foreach ($request->allFiles() as $key => $file) {
                 foreach (Arr::wrap($file) as $index => $singleFile) {
                     $service = $service->attach(
@@ -44,8 +52,6 @@ class PassageService implements PassageServiceInterface
 
             return $this->dispatch($service, $method, $uri, $request->post(), 'multipart');
         }
-
-        $contentType = $request->header('Content-Type', '');
 
         if (str_contains($contentType, 'application/x-www-form-urlencoded')) {
             return $this->dispatch($service->asForm(), $method, $uri, $request->post(), 'form_params');

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -267,5 +267,37 @@ describe('PassageService::callService()', function () {
 
             expect($this->service->callService($request, $pending, 'upload'))->toBe($mockResponse);
         });
+
+        it('forwards the parsed fields of a multipart/form-data request with no file fields', function () {
+            // Mirrors PHP's real behavior: multipart requests consume php://input
+            // into $_POST before userland code runs, so getContent() is empty.
+            $request = Request::create('/test', 'POST', ['field1' => 'hello', 'field2' => 'world'], [], [], [
+                'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+            ], '');
+
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('post')
+                ->once()
+                ->with('submit', ['field1' => 'hello', 'field2' => 'world'])
+                ->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'submit'))->toBe($mockResponse);
+        });
+
+        it('detects a multipart/form-data request with no files regardless of Content-Type casing', function () {
+            $request = Request::create('/test', 'POST', ['field1' => 'hello'], [], [], [
+                'CONTENT_TYPE' => 'MULTIPART/FORM-DATA; boundary=----boundary',
+            ], '');
+
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('post')
+                ->once()
+                ->with('submit', ['field1' => 'hello'])
+                ->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'submit'))->toBe($mockResponse);
+        });
     });
 });


### PR DESCRIPTION
## What was broken

`PassageService::callService()` only entered the multipart-aware branch when `$request->allFiles()` was non-empty. A `multipart/form-data` request with only text fields (no file fields) — a completely standard form submission — matched none of the earlier branches and fell into the raw-passthrough fallback, which builds the outbound body from `$request->getContent()`.

PHP consumes `php://input` while populating `$_POST`/`$_FILES` during request initialization for multipart requests, before any userland code runs, so `getContent()` is always empty for them. The fallback branch's `$body !== ''` check was therefore always false, and the upstream call was dispatched with **no body and none of the submitted fields** — silently, with no error or exception.

## What changed

- `src/Services/PassageService.php`: widened the multipart-handling condition to also trigger when the `Content-Type` header contains `multipart/form-data` (checked case-insensitively, matching the convention already used in `HasHmacAuth`), not just when files are present. Text-only multipart requests are now forwarded via `$request->post()`, the same as the existing file-upload path.
- `tests/Unit/PassageServiceTest.php`: added regression tests covering a multipart/form-data POST with only text fields (asserting the fields reach the outbound request), and one covering case-insensitive Content-Type detection.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (156 tests, 422 assertions)

Fixes #116