### PR TITLE
Fix crash on nested/grouped multipart file fields in HMAC signing and forwarding

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -3,7 +3,7 @@
 namespace Morcen\Passage\Concerns;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
+use Morcen\Passage\Support\NestedFileResolver;
 use RuntimeException;
 
 trait HasHmacAuth
@@ -100,15 +100,13 @@ trait HasHmacAuth
 
         $files = [];
 
-        foreach ($request->allFiles() as $key => $file) {
-            foreach (Arr::wrap($file) as $index => $singleFile) {
-                $files[is_array($file) ? "{$key}[{$index}]" : $key] = [
-                    'name' => $singleFile->getClientOriginalName(),
-                    'size' => $singleFile->getSize(),
-                    'mime' => $singleFile->getMimeType(),
-                    'hash' => hash('sha256', $singleFile->get()),
-                ];
-            }
+        foreach (NestedFileResolver::flatten($request->allFiles()) as $key => $singleFile) {
+            $files[$key] = [
+                'name' => $singleFile->getClientOriginalName(),
+                'size' => $singleFile->getSize(),
+                'mime' => $singleFile->getMimeType(),
+                'hash' => hash('sha256', $singleFile->get()),
+            ];
         }
 
         $encoded = json_encode([

--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -5,8 +5,8 @@ namespace Morcen\Passage\Services;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Morcen\Passage\Support\ForwardedHeaderResolver;
+use Morcen\Passage\Support\NestedFileResolver;
 
 class PassageService implements PassageServiceInterface
 {
@@ -39,15 +39,13 @@ class PassageService implements PassageServiceInterface
         // allFiles() being non-empty, so plain multipart forms aren't
         // dropped into the raw-passthrough branch below with no body.
         if (count($request->allFiles()) > 0 || str_contains(strtolower($contentType), 'multipart/form-data')) {
-            foreach ($request->allFiles() as $key => $file) {
-                foreach (Arr::wrap($file) as $index => $singleFile) {
-                    $service = $service->attach(
-                        is_array($file) ? "{$key}[{$index}]" : $key,
-                        $singleFile->get(),
-                        $singleFile->getClientOriginalName(),
-                        ['Content-Type' => $singleFile->getMimeType()]
-                    );
-                }
+            foreach (NestedFileResolver::flatten($request->allFiles()) as $key => $singleFile) {
+                $service = $service->attach(
+                    $key,
+                    $singleFile->get(),
+                    $singleFile->getClientOriginalName(),
+                    ['Content-Type' => $singleFile->getMimeType()]
+                );
             }
 
             return $this->dispatch($service, $method, $uri, $request->post(), 'multipart');

--- a/src/Support/NestedFileResolver.php
+++ b/src/Support/NestedFileResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Morcen\Passage\Support;
+
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Flattens the structure returned by Request::allFiles() into a flat map of
+ * bracket-notation key => UploadedFile.
+ *
+ * Symfony's FileBag::convertFileInformation() recursively nests arrays for
+ * bracket-style multipart field names (e.g. `docs[0][avatar]` produces
+ * ['docs' => [0 => ['avatar' => UploadedFile]]]) to an arbitrary depth, not
+ * just one level. Shared by HasHmacAuth (to sign each uploaded file) and
+ * PassageService (to attach each uploaded file to the outbound request),
+ * since both need to walk that structure to whatever depth it actually is.
+ */
+class NestedFileResolver
+{
+    public static function flatten(array $files): array
+    {
+        $flattened = [];
+
+        foreach ($files as $key => $file) {
+            self::walk((string) $key, $file, $flattened);
+        }
+
+        return $flattened;
+    }
+
+    private static function walk(string $key, mixed $file, array &$flattened): void
+    {
+        if ($file instanceof UploadedFile) {
+            $flattened[$key] = $file;
+
+            return;
+        }
+
+        foreach ($file as $index => $nested) {
+            self::walk("{$key}[{$index}]", $nested, $flattened);
+        }
+    }
+}

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -339,6 +339,34 @@ describe('HasHmacAuth', function () {
         expect($resultA->header('X-Signature'))->not->toBe($resultB->header('X-Signature'));
     });
 
+    it('signs a nested/grouped multipart file field instead of crashing', function () {
+        $handler = new HmacHandler;
+        $file = UploadedFile::fake()->createWithContent('id-card.png', 'card-bytes');
+
+        $request = Request::create('/test', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'multipart/form-data; boundary=----boundary',
+        ], '');
+        $request->files->set('docs', [0 => ['avatar' => $file]]);
+
+        $result = $handler->getRequest($request);
+
+        $timestamp = $result->header('X-Timestamp');
+        $signature = $result->header('X-Signature');
+        $expectedPayload = $timestamp.'.POST./test..'.json_encode([
+            'fields' => [],
+            'files' => [
+                'docs[0][avatar]' => [
+                    'name' => $file->getClientOriginalName(),
+                    'size' => $file->getSize(),
+                    'mime' => $file->getMimeType(),
+                    'hash' => hash('sha256', $file->get()),
+                ],
+            ],
+        ]);
+
+        expect($signature)->toBe(hash_hmac('sha256', $expectedPayload, 'super-secret'));
+    });
+
     it('detects multipart requests regardless of Content-Type casing', function () {
         $handler = new HmacHandler;
 

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -268,6 +268,22 @@ describe('PassageService::callService()', function () {
             expect($this->service->callService($request, $pending, 'upload'))->toBe($mockResponse);
         });
 
+        it('forwards a nested/grouped multipart file field without crashing', function () {
+            $file = UploadedFile::fake()->create('avatar.png', 10, 'image/png');
+            $request = Request::create('/test', 'POST');
+            $request->files->set('docs', [0 => ['avatar' => $file]]);
+
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('attach')
+                ->once()
+                ->with('docs[0][avatar]', $file->get(), 'avatar.png', ['Content-Type' => 'image/png'])
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('upload', [])->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'upload'))->toBe($mockResponse);
+        });
+
         it('forwards the parsed fields of a multipart/form-data request with no file fields', function () {
             // Mirrors PHP's real behavior: multipart requests consume php://input
             // into $_POST before userland code runs, so getContent() is empty.


### PR DESCRIPTION
## What was broken

`HasHmacAuth::resolveHmacSignedBody()` and `PassageService::callService()` both assumed `Request::allFiles()` nests file uploads at most one level deep (e.g. a plain field or a simple indexed array of files under one key).

Symfony's `FileBag::convertFileInformation()` actually builds arbitrarily deep nested arrays for bracket-style multipart field names. A field like `docs[0][avatar]` produces `['docs' => [0 => ['avatar' => UploadedFile]]]`. When either code path iterated one level into that structure, it found an array instead of an `UploadedFile` and crashed with an uncaught `Error: Call to a member function getClientOriginalName() on array` (or the equivalent in `PassageService`), turning an ordinary client request into a 500 instead of proxying it.

## What changed

- Added `Morcen\Passage\Support\NestedFileResolver::flatten()`, a small shared helper that recursively walks the structure returned by `allFiles()` to whatever depth it actually is, producing a flat map of bracket-notation keys (e.g. `docs[0][avatar]`) to their leaf `UploadedFile`.
- `HasHmacAuth::resolveHmacSignedBody()` now uses this helper to build the per-file metadata it signs, instead of assuming one level of nesting.
- `PassageService::callService()` now uses the same helper when attaching uploaded files to the outbound multipart request, fixing the identical bug that existed there.
- Added Pest tests covering a nested/grouped file field (`docs[0][avatar]`) for both the HMAC signing path and the outbound forwarding path, alongside the existing flat-file-field tests.

## Testing

- `vendor/bin/pint --dirty` — clean
- `composer test` — 158 passed (427 assertions)

Fixes #173
