### PR TITLE
Fix JSON responses being corrupted for empty or null bodies

### DIFF
--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -3,6 +3,7 @@
 namespace Morcen\Passage\Http;
 
 use Illuminate\Http\Client\Response;
+use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -29,12 +30,12 @@ class PassageResponseBuilder
         $headers = $this->resolveResponseHeaders($upstream);
         $contentType = $upstream->header('Content-Type');
 
-        if (str_contains($contentType, 'application/json')) {
-            return response()->json(
-                $upstream->json() ?? $body,
-                $status,
-                $headers
-            );
+        if (str_contains($contentType, 'application/json') && $body !== '') {
+            json_decode($body);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return JsonResponse::fromJsonString($body, $status, $headers);
+            }
         }
 
         $response = response($body, $status);

--- a/tests/Unit/PassageResponseBuilderTest.php
+++ b/tests/Unit/PassageResponseBuilderTest.php
@@ -62,6 +62,34 @@ describe('PassageResponseBuilder::build()', function () {
 
             expect($response->getStatusCode())->toBe(404);
         });
+
+        it('returns an empty body for a 204 response with an application/json content type', function () {
+            $upstream = upstreamMock('', 204, 'application/json');
+
+            $response = $this->builder->build($upstream);
+
+            expect($response)->not->toBeInstanceOf(JsonResponse::class);
+            expect($response->getStatusCode())->toBe(204);
+            expect($response->getContent())->toBe('');
+        });
+
+        it('returns a bare JSON null for a literal "null" body', function () {
+            $upstream = upstreamMock('null', 200, 'application/json');
+
+            $response = $this->builder->build($upstream);
+
+            expect($response)->toBeInstanceOf(JsonResponse::class);
+            expect($response->getContent())->toBe('null');
+        });
+
+        it('passes malformed JSON through untouched instead of double-encoding it', function () {
+            $upstream = upstreamMock('not valid json', 200, 'application/json');
+
+            $response = $this->builder->build($upstream);
+
+            expect($response)->not->toBeInstanceOf(JsonResponse::class);
+            expect($response->getContent())->toBe('not valid json');
+        });
     });
 
     describe('XML responses', function () {


### PR DESCRIPTION
## What was broken

`PassageResponseBuilder::build()` handled `Content-Type: application/json` upstream responses like this:

```php
if (str_contains($contentType, 'application/json')) {
    return response()->json(
        $upstream->json() ?? $body,
        $status,
        $headers
    );
}
```

`Response::json()` is a cached `json_decode($this->body(), true)`, which returns PHP `null` for two perfectly valid upstream responses:

1. An **empty body** — a `204 No Content`, a `304 Not Modified`, or any response that sends `Content-Type: application/json` with no payload.
2. A JSON body whose top-level value is the literal **`null`** — valid JSON.

In both cases the `?? $body` fallback passed the *raw string* body (`''` or `'null'`) into `response()->json($data, ...)`. But `JsonResponse` always `json_encode()`s whatever it's given, so:

- Empty body → the client received the two-character string `""` instead of an empty body.
- Body `null` → the client received the quoted string `"null"` instead of the bare JSON literal `null`.

The same double-encoding happened for any malformed/non-JSON body mislabeled with a JSON content type — `json_decode()` fails silently and the raw bytes get wrapped in a JSON string literal instead of surfacing the problem, silently corrupting Passage's "faithful passthrough" contract.

## What changed

`PassageResponseBuilder::build()` now only takes the JSON branch when the body actually decodes without a JSON error. When it does, the response is built with `JsonResponse::fromJsonString()`, which uses the already-validated raw bytes directly instead of round-tripping through `json_encode()` — so a literal `null` body comes back as a bare JSON `null`, not a quoted string. Anything that doesn't decode cleanly (an empty body, a malformed payload) now falls through to the existing plain-body branch, which returns the raw bytes untouched — the same thing already done for XML/text/binary responses.

Added regression tests for: an empty body with `application/json` content type, a literal `null` JSON body, and a malformed JSON body mislabeled as `application/json`.

Fixes #106
