### PR TITLE
Guard undefined CURLE_OPERATION_TIMEDOUT constant in error handler

### DIFF
--- a/src/Http/PassageErrorHandler.php
+++ b/src/Http/PassageErrorHandler.php
@@ -36,7 +36,8 @@ class PassageErrorHandler
             $cause = $e->getPrevious();
             if ($cause instanceof ConnectException) {
                 $context = $cause->getHandlerContext();
-                if (isset($context['errno']) && $context['errno'] === CURLE_OPERATION_TIMEDOUT) {
+                $timeoutErrno = $this->curlOperationTimedOutErrno();
+                if (isset($context['errno']) && $timeoutErrno !== null && $context['errno'] === $timeoutErrno) {
                     return Response::HTTP_GATEWAY_TIMEOUT; // 504
                 }
             }
@@ -49,6 +50,15 @@ class PassageErrorHandler
         }
 
         return Response::HTTP_INTERNAL_SERVER_ERROR; // 500
+    }
+
+    /**
+     * `CURLE_OPERATION_TIMEDOUT` only exists when PHP's curl extension is loaded;
+     * referencing it directly would throw a fatal error on curl-less installs.
+     */
+    protected function curlOperationTimedOutErrno(): ?int
+    {
+        return defined('CURLE_OPERATION_TIMEDOUT') ? CURLE_OPERATION_TIMEDOUT : null;
     }
 
     private function resolveMessage(Throwable $e, int $status): string

--- a/tests/Unit/PassageErrorHandlerTest.php
+++ b/tests/Unit/PassageErrorHandlerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use Illuminate\Http\Client\ConnectionException;
+use Morcen\Passage\Http\PassageErrorHandler;
+use Symfony\Component\HttpFoundation\Response as ResponseCode;
+
+function passageErrorHandlerRequest(): Psr7Request
+{
+    return new Psr7Request('GET', 'https://api.example.com/items');
+}
+
+it('returns 504 when the connect exception errno matches the curl timeout constant', function () {
+    $cause = new ConnectException(
+        'Operation timed out',
+        passageErrorHandlerRequest(),
+        null,
+        ['errno' => CURLE_OPERATION_TIMEDOUT]
+    );
+
+    $response = (new PassageErrorHandler)->handle(new ConnectionException('Timeout', 0, $cause));
+
+    expect($response->getStatusCode())->toBe(ResponseCode::HTTP_GATEWAY_TIMEOUT);
+    expect($response->getData(true))->toBe(['error' => 'Upstream service timed out.']);
+});
+
+it('returns 502 when the connect exception errno does not match the curl timeout constant', function () {
+    $cause = new ConnectException(
+        'Could not resolve host',
+        passageErrorHandlerRequest(),
+        null,
+        ['errno' => CURLE_COULDNT_RESOLVE_HOST]
+    );
+
+    $response = (new PassageErrorHandler)->handle(new ConnectionException('DNS failure', 0, $cause));
+
+    expect($response->getStatusCode())->toBe(ResponseCode::HTTP_BAD_GATEWAY);
+    expect($response->getData(true))->toBe(['error' => 'Upstream service is unreachable.']);
+});
+
+it('returns 502 when the connect exception has no handler context', function () {
+    $cause = new ConnectException('Connection refused', passageErrorHandlerRequest());
+
+    $response = (new PassageErrorHandler)->handle(new ConnectionException('Connection refused', 0, $cause));
+
+    expect($response->getStatusCode())->toBe(ResponseCode::HTTP_BAD_GATEWAY);
+});
+
+it('does not crash and falls back to 502 when the curl timeout constant is unavailable', function () {
+    // Simulates an install without ext-curl, where CURLE_OPERATION_TIMEDOUT is undefined.
+    $handler = new class extends PassageErrorHandler
+    {
+        protected function curlOperationTimedOutErrno(): ?int
+        {
+            return null;
+        }
+    };
+
+    $cause = new ConnectException(
+        'Operation timed out',
+        passageErrorHandlerRequest(),
+        null,
+        ['errno' => CURLE_OPERATION_TIMEDOUT]
+    );
+
+    $response = $handler->handle(new ConnectionException('Timeout', 0, $cause));
+
+    expect($response->getStatusCode())->toBe(ResponseCode::HTTP_BAD_GATEWAY);
+    expect($response->getData(true))->toBe(['error' => 'Upstream service is unreachable.']);
+});
+
+it('returns 502 for too many redirects', function () {
+    $exception = new TooManyRedirectsException('Too many redirects', passageErrorHandlerRequest());
+
+    $response = (new PassageErrorHandler)->handle($exception);
+
+    expect($response->getStatusCode())->toBe(ResponseCode::HTTP_BAD_GATEWAY);
+    expect($response->getData(true))->toBe(['error' => 'Upstream service is unreachable.']);
+});
+
+it('returns 500 for unexpected exceptions', function () {
+    $response = (new PassageErrorHandler)->handle(new RuntimeException('Something broke'));
+
+    expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
+    expect($response->getData(true))->toBe(['error' => 'An unexpected error occurred.']);
+});


### PR DESCRIPTION
## What was broken

`PassageErrorHandler::resolveStatus()` referenced curl's `CURLE_OPERATION_TIMEDOUT` constant directly:

```php
if (isset($context['errno']) && $context['errno'] === CURLE_OPERATION_TIMEDOUT) {
    return Response::HTTP_GATEWAY_TIMEOUT; // 504
}
```

That constant only exists when PHP's `curl` extension is loaded. Neither `composer.json` nor any runtime check requires `ext-curl` — Guzzle automatically falls back to its `StreamHandler` when curl is unavailable, so a minimal PHP install (e.g. a slim Docker image without `php-curl`) is a valid deployment target.

`PassageErrorHandler::handle()` is specifically responsible for turning a transport-level failure into a clean JSON error response for the client. On an environment without `ext-curl`, the first upstream `ConnectException` whose Guzzle handler context includes an `errno` key caused a fatal `Error: Undefined constant "CURLE_OPERATION_TIMEDOUT"` — the error handler itself crashed instead of producing the intended 502/504 response, turning a graceful "upstream unreachable" case into an unhandled 500 with no useful body.

## What changed

- Extracted the constant lookup into a small, overridable `curlOperationTimedOutErrno()` method that returns `null` via `defined()` when the constant isn't available, instead of referencing the bareword constant inline.
- Added `tests/Unit/PassageErrorHandlerTest.php` covering the previously untested `resolveStatus()` branches: the timeout-errno → 504 path, a non-timeout errno → 502 path, a missing-context → 502 path, the `TooManyRedirectsException` → 502 path, the generic-exception → 500 path, and a regression test that simulates the curl extension being unavailable (verifying the handler falls back to 502 instead of crashing).

Fixes #146

## Test plan

- [x] `vendor/bin/pint --dirty` — passed, no changes needed
- [x] `composer test` — full suite passes (167 tests, 445 assertions)