### PR TITLE
fix: never cache non-2xx upstream responses

### DIFF
--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -38,7 +38,9 @@ class PassageCacheManager
 
     /**
      * Store an upstream response in the cache.
-     * No-op for non-cacheable methods.
+     * No-op for non-cacheable methods or non-2xx responses, so a transient
+     * upstream failure is never frozen into the cache and replayed to every
+     * client for the full TTL.
      *
      * @param  int  $ttl  Cache time-to-live in seconds.
      * @param  array  $options  Request options used to generate the cache key.
@@ -50,7 +52,7 @@ class PassageCacheManager
      */
     public function put(string $method, string $fullUrl, int $ttl, array $options, Response $response, array $query = [], array $headers = []): void
     {
-        if (! $this->isCacheable($method)) {
+        if (! $this->isCacheable($method) || ! $response->successful()) {
             return;
         }
 

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -108,6 +108,7 @@ function jsonMockResponse(array $data = [], int $status = 200): Response
 {
     $mock = Mockery::mock(Response::class);
     $mock->shouldReceive('status')->andReturn($status);
+    $mock->shouldReceive('successful')->andReturn($status >= 200 && $status < 300);
     $mock->shouldReceive('json')->andReturn($data);
     $mock->shouldReceive('body')->andReturn(json_encode($data));
     $mock->shouldReceive('header')->with('Content-Type')->andReturn('application/json');
@@ -201,6 +202,29 @@ describe('3.2 Response caching', function () {
 
         expect($first->getStatusCode())->toBe(200);
         expect($second->getStatusCode())->toBe(200);
+    });
+
+    it('does not cache a non-2xx upstream response', function () {
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        $request = phase3Route(CachedHandler::class);
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // Both calls hit upstream: the first response is a transient 503, so it
+        // must never be cached and replayed to the second request.
+        $this->mockService->shouldReceive('callService')
+            ->twice()
+            ->andReturn(jsonMockResponse(['error' => 'unavailable'], 503));
+
+        $first = phase3Controller()->handle($request);
+        $second = phase3Controller()->handle(phase3Route(CachedHandler::class));
+
+        expect($first->getStatusCode())->toBe(503);
+        expect($second->getStatusCode())->toBe(503);
     });
 
     it('does not serve a cached response to a request with a different query string', function () {


### PR DESCRIPTION
## What was broken

`config/passage.php` sets Guzzle's `http_errors => false`, so upstream 4xx/5xx responses come back as ordinary `Response` objects rather than exceptions and flow through the same success path as a 200.

`PassageCacheManager::isCacheable()` only gated caching on HTTP method (GET/HEAD), never on response status, and `PassageController::handle()` called `cacheManager->put()` unconditionally whenever `passage_cache_ttl` was set on the route. This meant a single transient upstream failure — a 503 during a deploy, a rate-limit 429, or even a 404 for a resource that becomes valid moments later — got frozen into the cache and served to every client sharing that cache key for the entire TTL, turning a brief upstream blip into a sustained, package-induced outage for anyone using `passage_cache_ttl`.

## What changed

- `PassageCacheManager::put()` now also checks `$response->successful()` before storing a response, so non-2xx upstream responses are never cached.
- Added a regression test (`tests/Unit/Phase3Test.php`) asserting that a 503 upstream response is returned on both the first and second request instead of being cached and replayed on the second.

Fixes #172