### PR TITLE
Forward the raw form-urlencoded body instead of re-encoding it

### DIFF
--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -52,7 +52,14 @@ class PassageService implements PassageServiceInterface
         }
 
         if (str_contains($contentType, 'application/x-www-form-urlencoded')) {
-            return $this->dispatch($service->asForm(), $method, $uri, $request->post(), 'form_params');
+            // Forward the raw body verbatim instead of re-encoding $request->post()
+            // via asForm(): the parsed array has already been url-decoded and, for
+            // duplicate keys, collapsed to the last value, so re-encoding it can
+            // produce bytes that differ from what HasHmacAuth::resolveHmacSignedBody()
+            // signed (which signs the raw body for non-multipart requests).
+            $service = $service->withBody($request->getContent(), $contentType);
+
+            return $this->dispatch($service, $method, $uri);
         }
 
         $body = $request->getContent();

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -47,15 +47,31 @@ describe('PassageService::callService()', function () {
     });
 
     describe('POST requests', function () {
-        it('sends form-urlencoded body with asForm()', function () {
+        it('forwards the raw form-urlencoded body verbatim', function () {
             $request = Request::create('/test', 'POST', ['name' => 'Alice', 'role' => 'admin']);
             $mockResponse = Mockery::mock(Response::class);
             $pending = mockPending();
-            $pending->shouldReceive('asForm')->once()->andReturn($pending);
-            $pending->shouldReceive('post')
+            $pending->shouldReceive('withBody')
                 ->once()
-                ->with('users', ['name' => 'Alice', 'role' => 'admin'])
-                ->andReturn($mockResponse);
+                ->with($request->getContent(), 'application/x-www-form-urlencoded')
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('users')->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'users'))->toBe($mockResponse);
+        });
+
+        it('preserves duplicate keys in the forwarded form-urlencoded body', function () {
+            $body = 'a=1&a=2';
+            $request = Request::create('/test', 'POST', [], [], [], [
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            ], $body);
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('withBody')
+                ->once()
+                ->with($body, 'application/x-www-form-urlencoded')
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('users')->andReturn($mockResponse);
 
             expect($this->service->callService($request, $pending, 'users'))->toBe($mockResponse);
         });
@@ -98,11 +114,11 @@ describe('PassageService::callService()', function () {
             $request = Request::create('/test', 'PUT', ['status' => 'active']);
             $mockResponse = Mockery::mock(Response::class);
             $pending = mockPending();
-            $pending->shouldReceive('asForm')->once()->andReturn($pending);
-            $pending->shouldReceive('put')
+            $pending->shouldReceive('withBody')
                 ->once()
-                ->with('users/1', ['status' => 'active'])
-                ->andReturn($mockResponse);
+                ->with($request->getContent(), 'application/x-www-form-urlencoded')
+                ->andReturn($pending);
+            $pending->shouldReceive('put')->once()->with('users/1')->andReturn($mockResponse);
 
             expect($this->service->callService($request, $pending, 'users/1'))->toBe($mockResponse);
         });
@@ -111,12 +127,15 @@ describe('PassageService::callService()', function () {
     describe('DELETE requests', function () {
         it('sends DELETE with no body', function () {
             // Request::create() auto-sets application/x-www-form-urlencoded for DELETE.
-            // With no params, asForm() is called with an empty array — harmless but expected.
+            // With no params, withBody() is called with an empty string — harmless but expected.
             $request = Request::create('/test', 'DELETE');
             $mockResponse = Mockery::mock(Response::class);
             $pending = mockPending();
-            $pending->shouldReceive('asForm')->once()->andReturn($pending);
-            $pending->shouldReceive('delete')->once()->with('users/1', [])->andReturn($mockResponse);
+            $pending->shouldReceive('withBody')
+                ->once()
+                ->with('', 'application/x-www-form-urlencoded')
+                ->andReturn($pending);
+            $pending->shouldReceive('delete')->once()->with('users/1')->andReturn($mockResponse);
 
             expect($this->service->callService($request, $pending, 'users/1'))->toBe($mockResponse);
         });


### PR DESCRIPTION
## What was broken

`HasHmacAuth::resolveHmacSignedBody()` signs the raw, verbatim body of a non-multipart request (`$request->getContent()`). But for `application/x-www-form-urlencoded` requests, `PassageService::callService()` did not forward that raw body — it rebuilt the body from the parsed `$request->post()` array via Guzzle's `asForm()`.

`$request->post()` is a parsed representation: it has already been url-decoded and, for duplicate keys, collapsed to only the last value. Guzzle's `asForm()` then re-serializes that array with its own encoding. As a result, the bytes actually sent upstream could diverge from the raw bytes that were signed, for example:

- Duplicate keys: raw body `a=1&a=2` collapses to `a=2` after re-encoding.
- Array/bracket fields: `a[]=1&a[]=2` gets re-encoded with different bracket escaping.

This breaks the integrity guarantee HMAC signing is meant to provide — the signature is computed over bytes that differ from what the upstream service actually receives.

## What changed

`PassageService::callService()` now forwards the request's raw content verbatim (via `withBody()`) for `application/x-www-form-urlencoded` requests instead of re-encoding `$request->post()` through `asForm()`. This matches the raw-passthrough behavior already used for other content types (e.g. JSON, octet-stream) and ensures the signed bytes match the bytes actually sent upstream.

Tests in `tests/Unit/PassageServiceTest.php` were updated to assert the raw body is forwarded, including a new test asserting duplicate query keys are preserved verbatim.

Fixes #164