### PR TITLE
fix: enable Guzzle stream option when passage_streaming is set

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -98,6 +98,13 @@ class PassageController extends Controller
             $guzzleOptions['allow_redirects'] = $this->guardRedirects($guzzleOptions['allow_redirects'] ?? true);
         }
 
+        // Tell Guzzle to keep the upstream body as a lazily-read stream instead of
+        // buffering it into memory, so buildStreamedResponse() can actually stream
+        // it to the client rather than re-chunking an already-downloaded body.
+        if (! empty($passageOptions['passage_streaming'])) {
+            $guzzleOptions['stream'] = true;
+        }
+
         $pendingRequest = Http::withOptions($guzzleOptions);
 
         if (isset($passageOptions['passage_retry_times'])) {

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -433,11 +433,11 @@ describe('3.3 Upstream error handling', function () {
 });
 
 describe('3.4 Streaming', function () {
-    it('passage_streaming is stripped from guzzle options', function () {
+    it('passage_streaming is stripped from guzzle options and replaced with a Guzzle stream option', function () {
         $request = phase3Route(StreamingHandler::class);
 
         Http::shouldReceive('withOptions')
-            ->withArgs(fn (array $opts) => ! array_key_exists('passage_streaming', $opts))
+            ->withArgs(fn (array $opts) => ! array_key_exists('passage_streaming', $opts) && ($opts['stream'] ?? null) === true)
             ->once()
             ->andReturn(Mockery::mock(PendingRequest::class));
 
@@ -456,6 +456,21 @@ describe('3.4 Streaming', function () {
         $response = phase3Controller()->handle($request);
 
         expect($response)->toBeInstanceOf(StreamedResponse::class);
+        expect($response->getStatusCode())->toBe(200);
+    });
+
+    it('does not set the Guzzle stream option when passage_streaming is not enabled', function () {
+        $request = phase3Route(BaseUriOnlyHandler::class);
+
+        Http::shouldReceive('withOptions')
+            ->withArgs(fn (array $opts) => ! array_key_exists('stream', $opts))
+            ->once()
+            ->andReturn(Mockery::mock(PendingRequest::class));
+
+        $this->mockService->shouldReceive('callService')->once()->andReturn(jsonMockResponse());
+
+        $response = phase3Controller()->handle($request);
+
         expect($response->getStatusCode())->toBe(200);
     });
 });


### PR DESCRIPTION
## What was broken

The README documents `passage_streaming` as a way to avoid buffering large upstream responses in memory. In reality, enabling it only changed how the *already-fully-downloaded* response was written back to the client — Guzzle's `stream` request option was never set, so the Laravel HTTP client still downloaded the entire upstream body into memory before `PassageResponseBuilder::buildStreamedResponse()` re-chunked it in 4096-byte reads. This defeated the purpose of the feature and could cause the exact OOM/latency problems it claims to solve for large or long-running upstream responses.

## What changed

`PassageController::handle()` now sets `stream => true` on the Guzzle options passed to `Http::withOptions()` whenever `passage_streaming` is enabled, so the upstream body is read lazily from the connection instead of being fully buffered first.

Updated the existing streaming test to assert the `stream` option is actually set (in addition to `passage_streaming` being stripped from the options array), and added a test asserting the `stream` option is *not* set when `passage_streaming` is not enabled.

## Testing

- `vendor/bin/pint --dirty` — no changes needed
- `composer test` — full suite passes (170 tests, 456 assertions)

Fixes #166