### PR TITLE
fix: strip non-scalar guzzle options from cache key before serialize()

### DIFF
--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -86,7 +86,27 @@ class PassageCacheManager
         ksort($query);
         ksort($headers);
 
-        return 'passage:'.md5($method.$fullUrl.serialize($query).serialize($options).serialize($headers));
+        return 'passage:'.md5($method.$fullUrl.serialize($query).serialize($this->sanitizeForKey($options)).serialize($headers));
+    }
+
+    /**
+     * Strip non-scalar values (closures, streams, cookie jars, etc.) from a
+     * Guzzle options array before it is serialized into the cache key.
+     * Guzzle options accept callables (e.g. `on_stats`, `handler`) that
+     * serialize() cannot handle and that don't meaningfully identify a
+     * cached response anyway.
+     */
+    private function sanitizeForKey(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_map(fn ($item) => $this->sanitizeForKey($item), $value);
+        }
+
+        if (is_scalar($value) || $value === null) {
+            return $value;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -76,6 +76,18 @@ class BaseUriOnlyHandler extends PassageHandler
     }
 }
 
+class CachedHandlerWithCallableOption extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return [
+            'base_uri' => 'https://api.example.com/',
+            'passage_cache_ttl' => 60,
+            'on_stats' => function () {},
+        ];
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -374,6 +386,29 @@ describe('3.2 Response caching', function () {
 
         $first = phase3Controller()->handle(phase3Route(CachedHandler::class));
         $second = phase3Controller()->handle(phase3Route(CachedHandler::class));
+
+        expect($first->getStatusCode())->toBe(200);
+        expect($second->getStatusCode())->toBe(200);
+    });
+
+    it('serves a cached GET response when a handler sets a callable guzzle option', function () {
+        // Regression test for #84: PassageCacheManager::key() used to
+        // serialize() the full options array unconditionally, which throws
+        // when a handler sets a callable Guzzle option (e.g. on_stats)
+        // directly, crashing every request on the cached route.
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        $first = phase3Controller()->handle(phase3Route(CachedHandlerWithCallableOption::class));
+        $second = phase3Controller()->handle(phase3Route(CachedHandlerWithCallableOption::class));
 
         expect($first->getStatusCode())->toBe(200);
         expect($second->getStatusCode())->toBe(200);


### PR DESCRIPTION
## What was broken

`PassageCacheManager::key()` built the response-cache key with `serialize($options)`, called unconditionally on the full Guzzle options array returned by a handler's `getOptions()`.

Guzzle accepts callable options (`on_stats`, `handler`, custom middleware, etc.), and PHP's `serialize()` throws when it encounters a `Closure`. So any handler that combines `passage_cache_ttl` with a callable Guzzle option would crash on every single request to that route, not just the redirect-guard closure case that #124 already fixed (that fix only shields against the internally-injected `on_redirect` closure via a `$cacheableOptions` snapshot — it doesn't help if the handler itself returns a callable from `getOptions()`).

## What changed

- `PassageCacheManager::key()` now runs the options array through a new `sanitizeForKey()` helper before serializing it, which recursively strips non-scalar values (closures, streams, objects, etc.) and keeps everything else. These values can't meaningfully identify a cached response anyway, so dropping them from the key is safe.
- Added a regression test (`tests/Unit/Phase3Test.php`) with a handler that sets an `on_stats` closure alongside `passage_cache_ttl`, asserting the request succeeds and the cache is hit on the second call instead of throwing.

Fixes #84