### PR TITLE
fix: canonicalize nested query parameters in HMAC signing

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -73,14 +73,32 @@ trait HasHmacAuth
 
     /**
      * Resolve a canonical (key-sorted) query string so that reordering query
-     * parameters cannot change the signed payload.
+     * parameters — including nested/array parameters — cannot change the
+     * signed payload.
      */
     private function resolveHmacSignedQuery(Request $request): string
     {
         $query = $request->query();
-        ksort($query);
+        $this->recursiveKsort($query);
 
         return http_build_query($query);
+    }
+
+    /**
+     * Recursively key-sort an array in place so nested/array query
+     * parameters (e.g. filter[b]=2&filter[a]=1) canonicalize the same way
+     * regardless of the order the client submitted them in. ksort() alone
+     * only sorts the top-level keys, leaving nested arrays order-dependent.
+     */
+    private function recursiveKsort(array &$array): void
+    {
+        ksort($array);
+
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $this->recursiveKsort($value);
+            }
+        }
     }
 
     /**

--- a/tests/Unit/AuthTraitsTest.php
+++ b/tests/Unit/AuthTraitsTest.php
@@ -246,6 +246,24 @@ describe('HasHmacAuth', function () {
         );
     });
 
+    it('canonicalizes nested/array query parameters regardless of submission order', function () {
+        $handler = new HmacHandler;
+
+        $requestA = Request::create('/search?filter[a]=1&filter[b]=2', 'GET');
+        $requestB = Request::create('/search?filter[b]=2&filter[a]=1', 'GET');
+
+        $resultA = $handler->getRequest($requestA);
+        $resultB = $handler->getRequest($requestB);
+
+        $timestampA = $resultA->header('X-Timestamp');
+        $expected = hash_hmac('sha256', $timestampA.'.GET./search.'.http_build_query(['filter' => ['a' => '1', 'b' => '2']]).'.', 'super-secret');
+
+        expect($resultA->header('X-Signature'))->toBe($expected);
+        expect($resultA->header('X-Signature'))->toBe(
+            hash_hmac('sha256', $resultB->header('X-Timestamp').'.GET./search.'.http_build_query(['filter' => ['a' => '1', 'b' => '2']]).'.', 'super-secret')
+        );
+    });
+
     it('signs the parsed fields of a multipart request instead of the empty raw body', function () {
         $handler = new HmacHandler;
 


### PR DESCRIPTION
## What was broken

`HasHmacAuth::resolveHmacSignedQuery()` is documented as resolving "a canonical (key-sorted) query string so that reordering query parameters cannot change the signed payload," and calls `ksort($query)`. However, `ksort()` only sorts top-level array keys — nested/array query parameters (e.g. `filter[a]=1&filter[b]=2`) kept their original submission order.

As a result, two semantically identical requests with the same nested parameter values but different submission order (e.g. `filter[a]=1&filter[b]=2` vs `filter[b]=2&filter[a]=1`) produced different canonical query strings, and therefore different HMAC signatures. Any handler receiving array/nested query parameters (filters, sort criteria — common in REST APIs) could see legitimate, correctly-signed requests intermittently fail signature verification purely based on client-side parameter order, contradicting both the docblock and the existing test, which only exercised flat keys.

## What changed

- `resolveHmacSignedQuery()` now recursively sorts nested arrays (via a new `recursiveKsort()` helper) before building the canonical query string with `http_build_query()`, so nested parameters canonicalize consistently regardless of submission order.
- Added a regression test asserting that two requests with the same nested `filter[...]` parameters in different orders produce identical signatures.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — 172 tests passed (462 assertions)

Fixes #174