### PR TITLE
fix: disable response caching when streaming is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ public function getOptions(): array
 
 When streaming is enabled, the `getResponse()` transformation hook is skipped (the response body has not been read yet). The Content-Type and other upstream headers are still passed through.
 
+`passage_cache_ttl` and `passage_streaming` cannot be combined on the same handler: the upstream body is a single-pass stream, and reading it once for a cache write would leave nothing for the client. If a handler sets both, caching is silently disabled and every request is streamed straight through — set only one of the two options per handler.
+
 ---
 
 ## Observability

--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -144,8 +144,16 @@ class PassageController extends Controller
             return response()->json(['error' => $e->getMessage()], $e->getHttpStatus());
         }
 
+        // Streaming reads the upstream body as a lazy, single-pass PSR-7 stream (see the
+        // `stream => true` Guzzle option set above), so nothing else may consume that
+        // stream first. Caching is therefore disabled whenever streaming is enabled: a
+        // cache write would exhaust the stream before buildStreamedResponse() can read it,
+        // producing an empty/truncated response, and a cache hit would silently bypass
+        // streaming (and its getResponse() skip) for a response the handler asked to stream.
+        $isStreaming = ! empty($passageOptions['passage_streaming']);
+
         // Check cache before making the upstream call.
-        $cacheTtl = $passageOptions['passage_cache_ttl'] ?? null;
+        $cacheTtl = $isStreaming ? null : ($passageOptions['passage_cache_ttl'] ?? null);
         $fullUrl = rtrim($mergedOptions['base_uri'], '/').'/'.$path;
         // Same headers PassageService forwards upstream, so a cache entry is never
         // shared between requests that carry different credentials/identity.
@@ -185,7 +193,7 @@ class PassageController extends Controller
         }
 
         // Streaming: skip getResponse() hook and return directly.
-        if (! empty($passageOptions['passage_streaming'])) {
+        if ($isStreaming) {
             $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, $durationMs, false));
 
             return $this->responseBuilder->buildStreamedResponse($upstream);

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -68,6 +68,18 @@ class StreamingHandler extends PassageHandler
     }
 }
 
+class CachedStreamingHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return [
+            'base_uri' => 'https://api.example.com/',
+            'passage_cache_ttl' => 60,
+            'passage_streaming' => true,
+        ];
+    }
+}
+
 class BaseUriOnlyHandler extends PassageHandler
 {
     public function getOptions(): array
@@ -507,6 +519,51 @@ describe('3.4 Streaming', function () {
         $response = phase3Controller()->handle($request);
 
         expect($response->getStatusCode())->toBe(200);
+    });
+
+    it('does not truncate the streamed body when passage_cache_ttl is also set', function () {
+        // Regression test for #85: caching used to read the upstream body via
+        // Response::body() before buildStreamedResponse() got a chance to read
+        // from the same lazy PSR-7 stream, serving an empty/truncated body to
+        // the client. Caching is now disabled whenever streaming is enabled.
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        Http::shouldReceive('withOptions')
+            ->withArgs(fn (array $opts) => ($opts['stream'] ?? null) === true)
+            ->twice()
+            ->andReturn(Mockery::mock(PendingRequest::class));
+
+        $streamMockResponse = function () {
+            $upstream = Mockery::mock(Response::class);
+            $upstream->shouldReceive('status')->andReturn(200);
+            $upstream->shouldReceive('headers')->andReturn([]);
+            $upstream->shouldReceive('header')->with('Content-Type')->andReturn('text/event-stream');
+
+            $stream = Utils::streamFor('data: hello');
+            $psr7 = new GuzzleHttp\Psr7\Response(200, [], $stream);
+            $upstream->shouldReceive('toPsrResponse')->andReturn($psr7);
+
+            return $upstream;
+        };
+
+        // Both requests must reach the upstream: since caching is disabled while
+        // streaming, there is never a cache hit for this handler.
+        $this->mockService->shouldReceive('callService')
+            ->twice()
+            ->andReturn($streamMockResponse());
+
+        $first = phase3Controller()->handle(phase3Route(CachedStreamingHandler::class));
+
+        ob_start();
+        $first->sendContent();
+        $firstBody = ob_get_clean();
+
+        $second = phase3Controller()->handle(phase3Route(CachedStreamingHandler::class));
+
+        expect($first)->toBeInstanceOf(StreamedResponse::class);
+        expect($firstBody)->toBe('data: hello');
+        expect($second)->toBeInstanceOf(StreamedResponse::class);
     });
 });
 


### PR DESCRIPTION
## What was broken

When a handler set both `passage_cache_ttl` and `passage_streaming`, `PassageController::handle()` would call `cacheManager->put()` (which reads the upstream body via `Response::body()`) before `buildStreamedResponse()` got a chance to read from that same lazy PSR-7 stream.

This was a latent race until commit a569ac4 (#191) made `passage_streaming` actually set Guzzle's `stream => true` option. Once the upstream body became a real single-pass stream, `cacheManager->put()` fully exhausted it on the way to the cache, so `buildStreamedResponse()` had nothing left to read — every request that wrote to the cache served an empty or truncated body to the client.

A second, related inconsistency: a cache hit ran the handler's `getResponse()` transformation hook, while the live-streaming path explicitly skips it — so response-processing behavior differed between a cache hit and a live stream for the same handler.

## What changed

- `src/Http/Controllers/PassageController.php`: caching (both read and write) is now skipped entirely whenever `passage_streaming` is enabled on a handler. This guarantees the upstream stream is only ever read once, by `buildStreamedResponse()`, and removes the `getResponse()` inconsistency since a streaming handler's responses are never served from cache.
- `README.md`: documented that `passage_cache_ttl` and `passage_streaming` cannot be combined, and what happens if a handler sets both.
- `tests/Unit/Phase3Test.php`: added a regression test asserting the streamed body is delivered intact (not truncated) when a handler sets both options, and that caching never kicks in for it.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` — 173 passed (467 assertions)

Fixes #85