### PR TITLE
Fix retry() defaulting to retrying 4xx responses and swallowing final upstream errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,14 +406,16 @@ class PaymentsHandler extends PassageHandler
 php artisan passage:controller PaymentsHandler --with-retry
 ```
 
-`withRetry($times, $sleepMs, ?callable $when)` accepts an optional third argument — a callable that receives the exception and the pending request and returns `true` if the request should be retried:
+By default (no `$when` given), Passage only retries connection errors and 5xx responses — it never retries 4xx client errors, since retrying a non-idempotent upstream call after a `409`/`422` can cause duplicate side effects.
+
+`withRetry($times, $sleepMs, ?callable $when)` accepts an optional third argument — a callable that receives the exception and the pending request and returns `true` if the request should be retried — to customize this behavior:
 
 ```php
 $this->withRetry(
     times: 3,
     sleepMs: 200,
     when: function (\Exception $e, \Illuminate\Http\Client\PendingRequest $request) {
-        // Only retry on connection errors, not on 4xx responses
+        // Only retry connection errors, never HTTP error responses
         return $e instanceof \Illuminate\Http\Client\ConnectionException;
     }
 )

--- a/src/Concerns/HasResilienceOptions.php
+++ b/src/Concerns/HasResilienceOptions.php
@@ -2,6 +2,10 @@
 
 namespace Morcen\Passage\Concerns;
 
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Throwable;
+
 trait HasResilienceOptions
 {
     /**
@@ -13,7 +17,11 @@ trait HasResilienceOptions
      * @param  int  $times  Maximum number of retry attempts.
      * @param  int  $sleepMs  Milliseconds to wait between retries.
      * @param  callable|null  $when  Optional callable(Throwable $exception, PendingRequest $request): bool.
-     *                               When null, retries on connection errors and 5xx responses.
+     *                               When null, retries on connection errors and 5xx responses only —
+     *                               NOT on 4xx client errors, since Laravel's own retry default would
+     *                               otherwise retry any non-2xx response, including non-idempotent
+     *                               requests that already failed for a client-side reason (e.g. 409,
+     *                               422).
      *
      * Example:
      *   public function getOptions(): array
@@ -29,7 +37,26 @@ trait HasResilienceOptions
         return array_filter([
             'passage_retry_times' => $times,
             'passage_retry_sleep_ms' => $sleepMs,
-            'passage_retry_when' => $when,
+            'passage_retry_when' => $when ?? self::defaultRetryWhen(),
         ], fn ($v) => $v !== null);
+    }
+
+    /**
+     * Default retry predicate: connection errors and 5xx responses only.
+     *
+     * Laravel's own retry() default (when no $when callback is supplied)
+     * retries on any non-2xx response, including 4xx client errors. That is
+     * rarely what a Passage handler wants — retrying a 409/422 from a
+     * non-idempotent upstream operation can cause duplicate side effects.
+     */
+    private static function defaultRetryWhen(): callable
+    {
+        return function (Throwable $exception) {
+            if ($exception instanceof ConnectionException) {
+                return true;
+            }
+
+            return $exception instanceof RequestException && $exception->response->serverError();
+        };
     }
 }

--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -108,10 +108,17 @@ class PassageController extends Controller
         $pendingRequest = Http::withOptions($guzzleOptions);
 
         if (isset($passageOptions['passage_retry_times'])) {
+            // throw: false — Passage always forwards the upstream response as-is (see
+            // "Upstream 4xx and 5xx responses are passed through unchanged" below);
+            // without this, Laravel's retry() throws a RequestException for the final
+            // non-2xx response once $tries > 1, regardless of what $when decided, and
+            // that exception would be swallowed by the generic catch below and reported
+            // as an opaque 500 instead of the real upstream status/body.
             $pendingRequest = $pendingRequest->retry(
                 $passageOptions['passage_retry_times'],
                 $passageOptions['passage_retry_sleep_ms'] ?? 100,
                 $passageOptions['passage_retry_when'] ?? null,
+                throw: false,
             );
         }
 

--- a/tests/Feature/PassageIntegrationTest.php
+++ b/tests/Feature/PassageIntegrationTest.php
@@ -97,6 +97,17 @@ class HmacIntegrationHandler extends PassageHandler
     }
 }
 
+class DefaultRetryHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return array_merge(
+            ['base_uri' => 'https://retry.example.com/'],
+            $this->withRetry(3, 1)
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -278,6 +289,37 @@ describe('Passage Integration Tests', function () {
                 return $req->url() === 'https://partner.example.com/42/balance'
                     && $req->header('X-Signature')[0] === $expected;
             });
+        });
+    });
+
+    describe('Retry', function () {
+        it('retries on 5xx responses by default and eventually returns the last response', function () {
+            Http::fake([
+                'https://retry.example.com/*' => Http::sequence()
+                    ->push(['error' => 'boom'], 500)
+                    ->push(['error' => 'boom'], 500)
+                    ->push(['ok' => true], 200),
+            ]);
+            Passage::get('retry-5xx/{path?}', DefaultRetryHandler::class);
+
+            $this->get('/retry-5xx/resource')
+                ->assertStatus(200)
+                ->assertJson(['ok' => true]);
+
+            Http::assertSentCount(3);
+        });
+
+        it('does not retry on a 4xx response by default', function () {
+            Http::fake([
+                'https://retry.example.com/*' => Http::response(['error' => 'conflict'], 409),
+            ]);
+            Passage::get('retry-4xx/{path?}', DefaultRetryHandler::class);
+
+            $this->get('/retry-4xx/resource')
+                ->assertStatus(409)
+                ->assertJson(['error' => 'conflict']);
+
+            Http::assertSentCount(1);
         });
     });
 

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -1,8 +1,10 @@
 <?php
 
+use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -193,12 +195,66 @@ describe('3.1 Retry ergonomics', function () {
         phase3Controller()->handle($request);
     });
 
+    it('calls retry() with throw: false so the real upstream response is always returned', function () {
+        $request = phase3Route(RetryableHandler::class);
+
+        Http::shouldReceive('withOptions')->once()->andReturn(
+            Mockery::mock(PendingRequest::class)
+                ->shouldReceive('retry')
+                ->withArgs(fn ($times, $sleepMs, $when, $throw) => $throw === false)
+                ->once()
+                ->andReturnSelf()
+                ->getMock()
+        );
+
+        $this->mockService->shouldReceive('callService')
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        phase3Controller()->handle($request);
+    });
+
     it('withRetry() is available on PassageHandler subclasses', function () {
         $handler = new RetryableHandler;
         $opts = $handler->getOptions();
 
         expect($opts)->toHaveKey('passage_retry_times', 3);
         expect($opts)->toHaveKey('passage_retry_sleep_ms', 50);
+    });
+
+    it('withRetry() defaults passage_retry_when to connection errors and 5xx only, not 4xx', function () {
+        $handler = new class
+        {
+            use HasResilienceOptions;
+
+            public function options(): array
+            {
+                return $this->withRetry(3, 200);
+            }
+        };
+
+        $when = $handler->options()['passage_retry_when'];
+
+        expect($when)->toBeCallable();
+        expect($when(new ConnectionException('Connection timed out')))->toBeTrue();
+        expect($when(new RequestException(new Response(new Psr7Response(500)))))->toBeTrue();
+        expect($when(new RequestException(new Response(new Psr7Response(409)))))->toBeFalse();
+        expect($when(new RequestException(new Response(new Psr7Response(422)))))->toBeFalse();
+    });
+
+    it('withRetry() keeps an explicitly passed $when instead of the default', function () {
+        $custom = fn () => false;
+
+        $handler = new class
+        {
+            use HasResilienceOptions;
+
+            public function options(?callable $when): array
+            {
+                return $this->withRetry(3, 200, $when);
+            }
+        };
+
+        expect($handler->options($custom))->toHaveKey('passage_retry_when', $custom);
     });
 });
 
@@ -495,7 +551,7 @@ describe('3.4 Streaming', function () {
 
         // toPsrResponse() → PSR-7 Response with a stream body
         $stream = Utils::streamFor('data: hello');
-        $psr7 = new GuzzleHttp\Psr7\Response(200, [], $stream);
+        $psr7 = new Psr7Response(200, [], $stream);
         $upstreamMock->shouldReceive('toPsrResponse')->andReturn($psr7);
 
         $this->mockService->shouldReceive('callService')->once()->andReturn($upstreamMock);
@@ -541,7 +597,7 @@ describe('3.4 Streaming', function () {
             $upstream->shouldReceive('header')->with('Content-Type')->andReturn('text/event-stream');
 
             $stream = Utils::streamFor('data: hello');
-            $psr7 = new GuzzleHttp\Psr7\Response(200, [], $stream);
+            $psr7 = new Psr7Response(200, [], $stream);
             $upstream->shouldReceive('toPsrResponse')->andReturn($psr7);
 
             return $upstream;


### PR DESCRIPTION
## What was broken

`HasResilienceOptions::withRetry()` is documented as retrying "on connection errors and 5xx responses" when no `$when` callback is supplied. In practice, `$when` was passed straight through to Laravel's `PendingRequest::retry()`, whose own default retries on **any** non-2xx response, including 4xx client errors. Combined with `config/passage.php` setting `http_errors => false`, any handler calling `$this->withRetry(3, 200)` without a custom `$when` would silently retry `400`, `401`, `404`, `409`, `422`, etc. For a non-idempotent upstream operation (e.g. a `POST` that returns `409 Conflict` after partially processing), this can cause duplicate side effects.

A second, related bug surfaced while adding a regression test for the above: whenever `passage_retry_times` is set to more than 1, Laravel's `retry()` throws a `RequestException` for the *final* non-2xx response regardless of what `$when` decided (this is controlled by a separate `throw` flag, defaulting to `true`). That exception was being caught by `PassageController`'s generic error handler and reported as an opaque `500 Internal Server Error`, discarding the real upstream status code and body — violating the documented guarantee that "Upstream 4xx and 5xx responses are passed through unchanged."

## What changed

- `HasResilienceOptions::withRetry()` now supplies a default `$when` predicate (connection errors and 5xx responses only) when the caller doesn't pass one, matching the existing docblock.
- `PassageController` now calls `->retry(..., throw: false)`, so the real upstream response is always returned to the client instead of being converted into a generic 500 whenever retry is enabled.
- Updated the README's retry section to document the actual default behavior.
- Added unit tests for the default `$when` predicate and integration tests asserting retry counts for 5xx vs. 4xx upstream responses.

Fixes #108

## Testing

- `vendor/bin/pint --dirty`
- `composer test` (178 tests, 482 assertions, all passing)
