### PR TITLE
Forward original Content-Type for JSON requests instead of rewriting to application/json

### DIFF
--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -25,7 +25,7 @@ class PassageService implements PassageServiceInterface
         }
 
         if ($request->isJson()) {
-            $service = $service->withBody($request->getContent(), 'application/json');
+            $service = $service->withBody($request->getContent(), $request->header('Content-Type', 'application/json'));
 
             return $this->dispatch($service, $method, $uri);
         }

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -90,6 +90,20 @@ describe('PassageService::callService()', function () {
             expect($this->service->callService($request, $pending, 'users'))->toBe($mockResponse);
         });
 
+        it('forwards a vendor JSON content type unchanged instead of rewriting it to application/json', function () {
+            $body = json_encode(['op' => 'replace', 'path' => '/name', 'value' => 'Alice']);
+            $request = Request::create('/test', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/vnd.api+json'], $body);
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('withBody')
+                ->once()
+                ->with($body, 'application/vnd.api+json')
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('users')->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'users'))->toBe($mockResponse);
+        });
+
         it('separates query params from JSON body', function () {
             $body = json_encode(['name' => 'Alice']);
             $request = Request::create('/test?dry_run=1', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], $body);


### PR DESCRIPTION
## What was broken

`PassageService::callService()` hardcoded the outbound `Content-Type` to the literal string `application/json` for any request `$request->isJson()` considers JSON. Laravel/Symfony's `isJson()` returns `true` for any Content-Type containing `/json` or ending in `+json` — e.g. `application/vnd.api+json` (JSON:API), `application/merge-patch+json` (RFC 7396), `application/ld+json` — but the outbound header was always rewritten to the plain `application/json`, regardless of what the client actually sent.

This silently changes request semantics for upstream APIs that dispatch on the specific media type. For example, a PATCH meant as an RFC 7396 JSON Merge Patch would get relabeled as a plain JSON PATCH, or a JSON:API request would lose its vendor type — either of which can cause the upstream to reject or misinterpret the request.

Notably, the plain-body fallback a few lines below this JSON fast path already forwards the original Content-Type as-is, so this was also inconsistent with the rest of the method.

## What changed

- `src/Services/PassageService.php`: forward `$request->header('Content-Type', 'application/json')` instead of the hardcoded literal, so vendor/suffix JSON content types pass through unchanged (falling back to `application/json` only if no Content-Type header is present).
- `tests/Unit/PassageServiceTest.php`: added a regression test asserting a `application/vnd.api+json` request is forwarded with that same Content-Type rather than being rewritten.

Fixes #175