### PR TITLE
fix: compare allowlisted hosts case-insensitively in AllowedHostsGuard

### DIFF
--- a/src/Guards/AllowedHostsGuard.php
+++ b/src/Guards/AllowedHostsGuard.php
@@ -47,9 +47,9 @@ class AllowedHostsGuard
             return;
         }
 
-        $allowedHosts = config('passage.security.allowed_hosts', []);
+        $allowedHosts = array_map('strtolower', config('passage.security.allowed_hosts', []));
 
-        if (! in_array($host, $allowedHosts, strict: true)) {
+        if (! in_array(strtolower($host), $allowedHosts, strict: true)) {
             throw new DisallowedProxyTargetException(
                 "Upstream host [{$host}] is not in the passage allowed_hosts list."
             );

--- a/tests/Unit/AllowedHostsGuardTest.php
+++ b/tests/Unit/AllowedHostsGuardTest.php
@@ -48,6 +48,11 @@ describe('AllowedHostsGuard', function () {
             expect(fn () => $this->guard->check('not-a-url'))
                 ->toThrow(DisallowedProxyTargetException::class);
         });
+
+        it('permits an allowlisted host regardless of casing', function () {
+            expect(fn () => $this->guard->check('https://API.GitHub.com/v3/'))->not->toThrow(DisallowedProxyTargetException::class);
+            expect(fn () => $this->guard->check('https://Api.Stripe.Com/'))->not->toThrow(DisallowedProxyTargetException::class);
+        });
     });
 
     describe('checkHost()', function () {
@@ -77,6 +82,16 @@ describe('AllowedHostsGuard', function () {
 
             expect(fn () => $this->guard->checkHost('evil.example.com'))
                 ->toThrow(DisallowedProxyTargetException::class);
+        });
+
+        it('permits an allowlisted redirect target regardless of casing', function () {
+            config([
+                'passage.security.enforce_allowed_hosts' => true,
+                'passage.security.allowed_hosts' => ['api.github.com'],
+            ]);
+
+            expect(fn () => $this->guard->checkHost('API.GitHub.com'))
+                ->not->toThrow(DisallowedProxyTargetException::class);
         });
     });
 });


### PR DESCRIPTION
## What was broken

`AllowedHostsGuard::checkHost()` compared the upstream host against the configured `allowed_hosts` list with a strict, case-sensitive `in_array()`:

```php
if (! in_array($host, $allowedHosts, strict: true)) {
```

Hostnames are case-insensitive per RFC 3986 §3.2.2 / RFC 4343, and `parse_url()` does not normalize case. So if `allowed_hosts` contained `api.example.com` (lowercase) but a handler's `base_uri` was written as `https://API.example.com/` (or a redirect hop pointed to a differently-cased but otherwise allowlisted host), the guard would throw `DisallowedProxyTargetException` even though it's the exact same, correctly-allowlisted host — a fail-closed bug that rejects legitimate, correctly-configured upstream calls when `enforce_allowed_hosts` (the recommended production setting) is enabled.

This affected both the initial `base_uri` check and the redirect-hop revalidation added in a previous PR, since both funnel through `checkHost()`.

## What changed

- `AllowedHostsGuard::checkHost()` now lowercases both the incoming host and every entry in the configured `allowed_hosts` list before comparing, mirroring the case-insensitive normalization already used elsewhere in the codebase (e.g. `HasHmacAuth`'s Content-Type check).
- Added regression tests covering an allowlisted host with different casing, for both the `check()` (base_uri) and `checkHost()` (redirect target) entry points.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (181 tests, 489 assertions)

Fixes #109