### PR TITLE
fix: handle missing upstream Content-Type header without triggering a deprecation warning

### DIFF
--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -28,7 +28,7 @@ class PassageResponseBuilder
         $status = $upstream->status();
         $body = $upstream->body();
         $headers = $this->resolveResponseHeaders($upstream);
-        $contentType = $upstream->header('Content-Type');
+        $contentType = $upstream->header('Content-Type') ?? '';
 
         if (str_contains($contentType, 'application/json') && $body !== '') {
             json_decode($body);

--- a/tests/Unit/PassageResponseBuilderTest.php
+++ b/tests/Unit/PassageResponseBuilderTest.php
@@ -90,6 +90,20 @@ describe('PassageResponseBuilder::build()', function () {
             expect($response)->not->toBeInstanceOf(JsonResponse::class);
             expect($response->getContent())->toBe('not valid json');
         });
+
+        it('returns a plain response without warnings when the upstream omits Content-Type entirely', function () {
+            $upstream = Mockery::mock(Response::class);
+            $upstream->shouldReceive('status')->andReturn(204);
+            $upstream->shouldReceive('body')->andReturn('');
+            $upstream->shouldReceive('header')->with('Content-Type')->andReturn(null);
+            $upstream->shouldReceive('headers')->andReturn([]);
+
+            $response = $this->builder->build($upstream);
+
+            expect($response)->not->toBeInstanceOf(JsonResponse::class);
+            expect($response->getStatusCode())->toBe(204);
+            expect($response->getContent())->toBe('');
+        });
     });
 
     describe('XML responses', function () {


### PR DESCRIPTION
## What was broken

`PassageResponseBuilder::build()` read the upstream `Content-Type` header with no default value and passed it straight into `str_contains()`:

```php
$contentType = $upstream->header('Content-Type');
...
if (str_contains($contentType, 'application/json') && $body !== '') {
```

`Illuminate\Http\Client\Response::header()` returns `null` when the header is absent, and passing `null` as the haystack to `str_contains()` has been deprecated since PHP 8.1. Passage is a transparent proxy that must handle arbitrary upstream responses, including ones with no `Content-Type` header at all (e.g. a `204 No Content`). Depending on the application's error-reporting configuration, this could pollute logs on every such response, or turn a perfectly valid response into a hard failure for apps that convert deprecations to exceptions.

## What changed

- Default the upstream `Content-Type` lookup to an empty string before the `str_contains()` check in `src/Http/PassageResponseBuilder.php`.
- Added a regression test in `tests/Unit/PassageResponseBuilderTest.php` covering an upstream response with no `Content-Type` header at all, asserting `build()` returns a plain (non-JSON) response.

Fixes #119