### PR TITLE
fix: exclude volatile headers from the response cache key

### DIFF
--- a/config/passage.php
+++ b/config/passage.php
@@ -112,6 +112,15 @@ return [
 
     'cache' => [
         'store' => env('PASSAGE_CACHE_STORE', null),
+
+        /*
+        | Forwarded headers excluded from the cache key. Some headers are
+        | deliberately regenerated on every request (e.g. HasHmacAuth's
+        | X-Timestamp/X-Signature), so including them makes every request
+        | produce a different key and caching never hits. Add any other
+        | per-request volatile header your handlers set here.
+        */
+        'volatile_headers' => ['X-Timestamp', 'X-Signature'],
     ],
 
     /*

--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -79,14 +79,35 @@ class PassageCacheManager
      * Generate a unique cache key for the request.
      *
      * Forwarded headers (e.g. Authorization) are included so two requests that
-     * produce different outbound headers never share a cached response.
+     * produce different outbound headers never share a cached response. Headers
+     * configured as volatile (e.g. HasHmacAuth's X-Timestamp/X-Signature) are
+     * excluded first, since they change on every request by design and would
+     * otherwise make every cache key unique, defeating caching entirely.
      */
     private function key(string $method, string $fullUrl, array $options, array $query = [], array $headers = []): string
     {
         ksort($query);
+        $headers = $this->excludeVolatileHeaders($headers);
         ksort($headers);
 
         return 'passage:'.md5($method.$fullUrl.serialize($query).serialize($this->sanitizeForKey($options)).serialize($headers));
+    }
+
+    /**
+     * Remove headers configured as volatile (regenerated on every request,
+     * e.g. by HasHmacAuth::withHmacSignature()) from the headers used to
+     * build the cache key. Matching is case-insensitive since header names
+     * are compared regardless of casing.
+     */
+    private function excludeVolatileHeaders(array $headers): array
+    {
+        $volatile = array_map('strtolower', config('passage.cache.volatile_headers', []));
+
+        return array_filter(
+            $headers,
+            fn (string $name) => ! in_array(strtolower($name), $volatile, strict: true),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 
     /**

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Morcen\Passage\Concerns\HasHmacAuth;
 use Morcen\Passage\Concerns\HasResilienceOptions;
 use Morcen\Passage\Contracts\AcceptsClientHeaders;
 use Morcen\Passage\Events\PassageRequestFailed;
@@ -99,6 +100,21 @@ class CachedHandlerWithCallableOption extends PassageHandler
             'passage_cache_ttl' => 60,
             'on_stats' => function () {},
         ];
+    }
+}
+
+class CachedHandlerWithHmacAuth extends PassageHandler
+{
+    use HasHmacAuth;
+
+    public function getRequest(Request $request): Request
+    {
+        return $this->withHmacSignature($request, 'super-secret');
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com/', 'passage_cache_ttl' => 60];
     }
 }
 
@@ -381,6 +397,33 @@ describe('3.2 Response caching', function () {
 
         expect($firstResponse->getStatusCode())->toBe(200);
         expect($secondResponse->getStatusCode())->toBe(200);
+    });
+
+    it('serves a cached response even when a handler injects HMAC signature headers that change per request', function () {
+        // Regression test for #132: HasHmacAuth::withHmacSignature() sets
+        // X-Timestamp/X-Signature headers that differ on every request by
+        // design. Previously these flowed into the cache key unfiltered, so
+        // every request produced a different key and passage_cache_ttl never
+        // hit — silently defeating caching whenever HMAC auth was combined
+        // with it.
+        Cache::flush();
+        config(['passage.cache.store' => 'array']);
+
+        Http::shouldReceive('withOptions')->twice()->andReturn(
+            Mockery::mock(PendingRequest::class)
+        );
+
+        // Same request signed twice: the timestamp/signature differ each
+        // time, but caching should still hit on the second call.
+        $this->mockService->shouldReceive('callService')
+            ->once()
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        $first = phase3Controller()->handle(phase3Route(CachedHandlerWithHmacAuth::class));
+        $second = phase3Controller()->handle(phase3Route(CachedHandlerWithHmacAuth::class));
+
+        expect($first->getStatusCode())->toBe(200);
+        expect($second->getStatusCode())->toBe(200);
     });
 
     it('does not cache non-GET methods', function () {


### PR DESCRIPTION
## What was broken

`PassageCacheManager` builds its cache key from the forwarded request headers (`src/Http/PassageCacheManager.php`), so that two requests with different credentials never share a cached response.

If a handler combines `passage_cache_ttl` (from `getOptions()`) with `HasHmacAuth::withHmacSignature()` inside `getRequest()`, the request carries `X-Timestamp`/`X-Signature` headers that change on every single call by design (the timestamp is `time()`, and the signature is derived from it). Since these headers flowed unfiltered into the cache key, **every request produced a different cache key**, so `passage_cache_ttl` never hit — silently, with no error, warning, or log line indicating caching was defeated.

## What changed

- Added a configurable `passage.cache.volatile_headers` option (`config/passage.php`), defaulting to `['X-Timestamp', 'X-Signature']` — the headers `HasHmacAuth::withHmacSignature()` sets.
- `PassageCacheManager::key()` now excludes these headers (case-insensitively) before hashing the cache key, while the actual headers forwarded upstream (via `ForwardedHeaderResolver`) are untouched.
- Added a regression test in `tests/Unit/Phase3Test.php` with a handler using `HasHmacAuth`, asserting the second identical request is served from cache instead of hitting upstream again.

## Testing

- `vendor/bin/pint --dirty` — no changes needed
- `composer test` — 183 passed (496 assertions)

Fixes #132