### PR TITLE
fix: prevent passage:health from aborting when a handler throws

### DIFF
--- a/src/Commands/PassageHealthCommand.php
+++ b/src/Commands/PassageHealthCommand.php
@@ -45,8 +45,16 @@ class PassageHealthCommand extends Command
                 continue;
             }
 
-            $handlerInstance = app($handler);
-            $options = array_merge(config('passage.options', []), $handlerInstance->getOptions());
+            try {
+                $handlerInstance = app($handler);
+                $options = array_merge(config('passage.options', []), $handlerInstance->getOptions());
+            } catch (Throwable $e) {
+                $rows[] = [class_basename($handler), '—', '<fg=red>FAIL</>', 'Could not resolve handler: '.$e->getMessage()];
+                $anyFailed = true;
+
+                continue;
+            }
+
             $baseUri = $options['base_uri'] ?? null;
 
             if (! $baseUri) {

--- a/tests/Unit/PassageHealthCommandTest.php
+++ b/tests/Unit/PassageHealthCommandTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Morcen\Passage\Facades\Passage;
+use Morcen\Passage\PassageControllerInterface;
+
+class HealthCommandTestPassageController implements PassageControllerInterface
+{
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com'];
+    }
+}
+
+class NoBaseUriHealthCommandPassageController implements PassageControllerInterface
+{
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return [];
+    }
+}
+
+class ThrowingHealthCommandPassageController implements PassageControllerInterface
+{
+    public function __construct()
+    {
+        throw new RuntimeException('unresolvable dependency');
+    }
+
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com'];
+    }
+}
+
+describe('PassageHealthCommand', function () {
+    it('warns when passage is disabled', function () {
+        config()->set('passage.enabled', false);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('Passage is disabled')
+            ->assertExitCode(0);
+    });
+
+    it('warns when no Passage routes are registered', function () {
+        config()->set('passage.enabled', true);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('No Passage routes are registered')
+            ->assertExitCode(0);
+    });
+
+    it('reports OK for a reachable route', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(0);
+    });
+
+    it('fails when a route has no base_uri configured', function () {
+        config()->set('passage.enabled', true);
+
+        Passage::get('no-base-uri/{path?}', NoBaseUriHealthCommandPassageController::class);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('SKIPPED')
+            ->assertExitCode(0);
+    });
+
+    it('continues checking other routes when a handler cannot be resolved', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('broken/{path?}', ThrowingHealthCommandPassageController::class);
+        Passage::post('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('Could not resolve handler: unresolvable dependency')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(1);
+    });
+
+    it('reports failure when a handler cannot be resolved even if no other routes exist', function () {
+        config()->set('passage.enabled', true);
+
+        Passage::get('broken/{path?}', ThrowingHealthCommandPassageController::class);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain(ThrowingHealthCommandPassageController::class)
+            ->assertExitCode(1);
+    });
+});


### PR DESCRIPTION
## What was broken

`PassageHealthCommand::handle()` resolved each registered route's handler and called `getOptions()` with no exception handling:

```php
$handlerInstance = app($handler);
$options = array_merge(config('passage.options', []), $handlerInstance->getOptions());
```

Its sibling command, `PassageListCommand::resolveTarget()`, already wraps the equivalent resolution in a `try`/`catch (Throwable)`, but `PassageHealthCommand` did not.

Since nothing in `PassageControllerInterface` forbids constructor-injected dependencies, a handler that fails to resolve (e.g. an unresolvable constructor dependency) or whose `getOptions()` throws would let the exception propagate out of the loop and abort the entire command with an uncaught exception. No table was printed at all, not even for the other, perfectly healthy routes. `passage:health` is recommended in the README for CI pipelines and post-deployment checks, so one misconfigured handler made the whole diagnostic command unusable.

## What changed

- `src/Commands/PassageHealthCommand.php`: wrapped handler resolution (`app($handler)` and `getOptions()`) in a `try`/`catch (Throwable)`, mirroring `PassageListCommand`. On failure, the command now emits a `FAIL` row with the exception message and marks the run as failed, instead of aborting outright, so the rest of the routes still get checked and reported.
- `tests/Unit/PassageHealthCommandTest.php`: added test coverage for `PassageHealthCommand`, which previously had none, including a regression test for a handler whose constructor throws, asserting the command still completes and reports the other routes.

Fixes #149

## Testing

- `vendor/bin/pint --dirty`
- `composer test` (full suite, 189 tests passing)