### PR TITLE
fix: report unexpected exceptions from the proxy request path

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -3,7 +3,6 @@
 namespace Morcen\Passage\Http\Controllers;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
@@ -186,7 +185,7 @@ class PassageController extends Controller
             $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));
 
             return response()->json(['error' => 'Upstream host is not permitted.'], Response::HTTP_FORBIDDEN);
-        } catch (ConnectionException|Throwable $e) {
+        } catch (Throwable $e) {
             $durationMs = (microtime(true) - $startedAt) * 1000;
             $this->fireEvent(new PassageRequestFailed($request, $handler, $e, $durationMs));
 

--- a/src/Http/PassageErrorHandler.php
+++ b/src/Http/PassageErrorHandler.php
@@ -17,9 +17,18 @@ class PassageErrorHandler
      * Upstream 4xx/5xx responses are NOT exceptions and must NOT be passed here —
      * they travel through PassageResponseBuilder as normal responses.
      * Only connection-level failures (timeouts, DNS, TLS, redirect loops) reach this handler.
+     *
+     * Every exception handled here is reported through Laravel's normal exception
+     * pipeline (report()), so it always reaches the configured log channel and any
+     * wired error tracker (Sentry, Bugsnag, ...) — regardless of whether the optional
+     * PassageEventSubscriber is registered. Without this, a genuine bug (as opposed to
+     * an upstream connectivity failure) would be silently converted into a generic
+     * error response with no trace anywhere.
      */
     public function handle(Throwable $e): JsonResponse
     {
+        report($e);
+
         $status = $this->resolveStatus($e);
 
         return response()->json(

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
@@ -324,6 +325,35 @@ describe('PassageController', function () {
         expect(json_decode($response->getContent(), true))->toBe([
             'error' => 'Upstream host is not permitted.',
         ]);
+    });
+
+    it('reports an unexpected exception from callService instead of silently swallowing it', function () {
+        Event::fake([PassageRequestFailed::class]);
+
+        $request = Request::create('/github/users/123', 'GET');
+        $route = (new Route(['GET'], '/github/{path?}', []))
+            ->defaults('_passage_handler', TestPassageController::class);
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        $mockPendingRequest = Mockery::mock(PendingRequest::class);
+        Http::shouldReceive('withOptions')->once()->andReturn($mockPendingRequest);
+
+        $exception = new RuntimeException('Unexpected bug in a custom handler');
+        $this->mockPassageService->shouldReceive('callService')->once()->andThrow($exception);
+
+        $this->mock(ExceptionHandler::class)
+            ->shouldReceive('report')
+            ->once()
+            ->with($exception);
+
+        $response = $this->controller->handle($request);
+
+        expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
+
+        Event::assertDispatched(PassageRequestFailed::class, function (PassageRequestFailed $event) use ($exception) {
+            return $event->exception === $exception;
+        });
     });
 
     it('wires an on_redirect guard into allow_redirects that blocks disallowed redirect hosts', function () {

--- a/tests/Unit/PassageErrorHandlerTest.php
+++ b/tests/Unit/PassageErrorHandlerTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Psr7\Request as Psr7Request;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Client\ConnectionException;
 use Morcen\Passage\Http\PassageErrorHandler;
 use Symfony\Component\HttpFoundation\Response as ResponseCode;
@@ -85,4 +86,26 @@ it('returns 500 for unexpected exceptions', function () {
 
     expect($response->getStatusCode())->toBe(ResponseCode::HTTP_INTERNAL_SERVER_ERROR);
     expect($response->getData(true))->toBe(['error' => 'An unexpected error occurred.']);
+});
+
+it('reports every handled exception through Laravel\'s exception handler', function () {
+    $exception = new RuntimeException('Something broke');
+
+    $this->mock(ExceptionHandler::class)
+        ->shouldReceive('report')
+        ->once()
+        ->with($exception);
+
+    (new PassageErrorHandler)->handle($exception);
+});
+
+it('still reports a connection-level exception, not just unexpected ones', function () {
+    $exception = new ConnectionException('Timeout');
+
+    $this->mock(ExceptionHandler::class)
+        ->shouldReceive('report')
+        ->once()
+        ->with($exception);
+
+    (new PassageErrorHandler)->handle($exception);
 });


### PR DESCRIPTION
## What was broken

`PassageController::handle()` wraps every upstream call in a blanket catch:

```php
try {
    $upstream = $this->passageService->callService($request, $pendingRequest, $path);
} catch (ConnectionException|Throwable $e) {
    ...
    return $this->errorHandler->handle($e);
}
```

`PassageErrorHandler::handle()`'s own docblock says only connection-level failures (timeouts, DNS, TLS, redirect loops) are meant to reach it, but the catch clause actually catches *any* `Throwable` — a `TypeError` or other genuine bug inside a custom `PassageServiceInterface` implementation gets funneled through the same path and reported to the client as a generic "Upstream service unreachable" or "An unexpected error occurred", mischaracterizing an internal bug as an upstream connectivity problem.

Worse, that exception was never logged by default. `PassageEventSubscriber` (the only place that logs `PassageRequestFailed`) is explicitly opt-in and not registered automatically, and Laravel's own exception handler / `report()` was never invoked — the exception was fully caught and converted into a response instead of being reported. Out of the box, a genuine bug in a handler produced a 500/502 to the client with zero trace anywhere in the application's logs or error tracker, making it very hard to diagnose in production.

## What changed

- `PassageErrorHandler::handle()` now calls `report($e)` before building the response, so every exception it handles always reaches the app's normal exception-reporting pipeline (configured log channel, Sentry, Bugsnag, etc.), regardless of whether `PassageEventSubscriber` is registered.
- Simplified `catch (ConnectionException|Throwable $e)` to `catch (Throwable $e)` in `PassageController::handle()`, since `ConnectionException` already implements `Throwable` — the union type was redundant and misleading.
- Added tests asserting `PassageErrorHandler::handle()` reports every exception it handles (both connection-level and unexpected ones) through Laravel's `ExceptionHandler` contract, and a `PassageController` test asserting an unexpected exception thrown from `callService()` is reported rather than silently swallowed.

Fixes #114
