### PR TITLE
Report failure for passage:health routes with missing or invalid handler class

### DIFF
--- a/src/Commands/PassageHealthCommand.php
+++ b/src/Commands/PassageHealthCommand.php
@@ -41,7 +41,14 @@ class PassageHealthCommand extends Command
         foreach ($routes as $route) {
             $handler = $route->defaults['_passage_handler'] ?? null;
 
-            if (! $handler || ! class_exists($handler) || ! is_subclass_of($handler, PassageControllerInterface::class)) {
+            if (! $handler) {
+                continue;
+            }
+
+            if (! class_exists($handler) || ! is_subclass_of($handler, PassageControllerInterface::class)) {
+                $rows[] = [class_basename($handler), '—', '<fg=red>FAIL</>', 'Invalid or missing handler class'];
+                $anyFailed = true;
+
                 continue;
             }
 

--- a/tests/Unit/PassageHealthCommandTest.php
+++ b/tests/Unit/PassageHealthCommandTest.php
@@ -127,4 +127,28 @@ describe('PassageHealthCommand', function () {
             ->expectsOutputToContain(ThrowingHealthCommandPassageController::class)
             ->assertExitCode(1);
     });
+
+    it('fails when a route has a missing or invalid handler class', function () {
+        config()->set('passage.enabled', true);
+
+        Passage::get('missing-handler/{path?}', 'App\\Handlers\\DeletedPassageController');
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('Invalid or missing handler class')
+            ->assertExitCode(1);
+    });
+
+    it('still checks other routes when a route has a missing handler class', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('missing-handler/{path?}', 'App\\Handlers\\DeletedPassageController');
+        Passage::post('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('FAIL')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(1);
+    });
 });


### PR DESCRIPTION
## What was broken

`PassageHealthCommand::handle()` (`passage:health`) silently skipped any route whose handler class was missing or did not implement `PassageControllerInterface` — for example after a refactor deletes or renames a handler class. The route was dropped with no row in the output table, and the overall run's `$anyFailed` flag was never set, so the command could exit `0` ("all healthy") for a route that is guaranteed to fail on its next real request.

This defeats the purpose of `passage:health` as a CI/deployment gate: it reports green while a registered route is completely broken.

## What changed

- Routes with a missing or invalid handler class are now reported as a `FAIL` row (with an `Invalid or missing handler class` detail message) and mark the command as failed, so it exits non-zero — consistent with how other failure conditions (e.g. an unresolvable handler) are already handled in this command.
- Routes with no `_passage_handler` default at all (not a Passage route in practice) continue to be skipped, unchanged.
- Added tests covering: a route with a missing/invalid handler class causing a failing exit code, and that other healthy routes are still checked when one route has an invalid handler.

Fixes #150