### PR TITLE
fix(health): validate --timeout option to prevent CI hangs

### DIFF
--- a/src/Commands/PassageHealthCommand.php
+++ b/src/Commands/PassageHealthCommand.php
@@ -34,7 +34,7 @@ class PassageHealthCommand extends Command
             return self::SUCCESS;
         }
 
-        $timeout = (int) $this->option('timeout');
+        $timeout = $this->resolveTimeout($this->option('timeout'));
         $rows = [];
         $anyFailed = false;
 
@@ -87,6 +87,24 @@ class PassageHealthCommand extends Command
         $this->table(['Handler', 'Base URI', 'Status', 'Detail'], $rows);
 
         return $anyFailed ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Cast the --timeout option to a positive integer, falling back to the
+     * documented default of 5 seconds for non-numeric or non-positive input.
+     * A bare (int) cast would silently turn "abc" or "0" into 0, which
+     * Http::timeout() treats as "wait indefinitely" — risking a hung CI job
+     * instead of a fast, actionable failure.
+     */
+    private function resolveTimeout(mixed $timeout): int
+    {
+        if (! is_numeric($timeout) || (int) $timeout <= 0) {
+            $this->warn("Invalid --timeout value \"{$timeout}\"; using the default of 5 seconds instead.");
+
+            return 5;
+        }
+
+        return (int) $timeout;
     }
 
     private function probe(string $baseUri, int $timeout): array

--- a/tests/Unit/PassageHealthCommandTest.php
+++ b/tests/Unit/PassageHealthCommandTest.php
@@ -151,4 +151,56 @@ describe('PassageHealthCommand', function () {
             ->expectsOutputToContain('OK')
             ->assertExitCode(1);
     });
+
+    it('falls back to the default timeout and warns when --timeout is zero', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health', ['--timeout' => '0'])
+            ->expectsOutputToContain('Invalid --timeout value')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(0);
+    });
+
+    it('falls back to the default timeout and warns when --timeout is non-numeric', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health', ['--timeout' => 'abc'])
+            ->expectsOutputToContain('Invalid --timeout value')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(0);
+    });
+
+    it('falls back to the default timeout and warns when --timeout is negative', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health', ['--timeout' => '-5'])
+            ->expectsOutputToContain('Invalid --timeout value')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(0);
+    });
+
+    it('accepts a valid positive --timeout without warning', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health', ['--timeout' => '10'])
+            ->doesntExpectOutputToContain('Invalid --timeout value')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(0);
+    });
 });


### PR DESCRIPTION
## What was broken

`passage:health` cast the `--timeout` option with a bare `(int)` cast:

```php
$timeout = (int) $this->option('timeout');
...
Http::timeout($timeout)->head($baseUri);
```

A non-numeric value (e.g. `--timeout=abc`) or an explicit `--timeout=0` both cast to `0`. `Http::timeout()` treats `0` as "wait indefinitely" — the same convention documented in `config/passage.php` for the package's own HTTP client options. Since the README recommends running `passage:health` in CI pipelines and post-deployment checks, a malformed or zero timeout could hang a deployment job indefinitely instead of failing fast with an actionable error.

## What changed

- Added `PassageHealthCommand::resolveTimeout()`, which rejects non-numeric and non-positive `--timeout` values, warns the operator, and falls back to the documented default of 5 seconds instead of waiting forever.
- Added regression tests covering `--timeout=0`, a non-numeric value, a negative value, and confirming a valid positive timeout passes through without a warning.

## Testing

- `vendor/bin/pint --dirty`
- `composer test` (198 passed)

Fixes #178