### PR TITLE
chore(release): v3.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "morcen/passage",
-    "version": "v3.1.0",
+    "version": "v3.1.1",
     "description": "API gateway for Laravel",
     "keywords": [
         "morcen",


### PR DESCRIPTION
## Summary

Bumps the package version from `v3.1.0` to `v3.1.1`.

This is a patch release: every commit merged to `main` since `v3.1.0` is a bug/security fix (or non-user-facing chore/docs/refactor/test/style/build/ci work) — no new features and no breaking changes.

### Notable fixes since v3.1.0

- Reject dot-segment traversal paths in proxied requests (#103)
- Normalize forwarded header casing for uppercase header names (#94)
- Include forwarded headers in the response cache key to prevent cross-user data leakage (#115)
- Re-validate redirect targets against `allowed_hosts` to prevent SSRF (#117)
- Bind the HMAC signature to HTTP method, path, and query string (#145)
- Include file content hash in the HMAC signature for multipart requests (#156)
- Strip `proxy-authorization` from published hop-by-hop headers config (#162)
- Bind the HMAC signature to the path actually forwarded upstream (#165)
- Match multipart `Content-Type` case-insensitively in HMAC signing (#181)
- Dispatch `OPTIONS` requests via `send()` instead of an undefined magic method (#170)
- Stop leaking internal handler class names and hostnames in error responses (#184)
- Forward multipart/form-data fields when a request has no files (#185)
- Recursively flatten nested multipart file fields for HMAC signing and forwarding (#186)
- Stop corrupting JSON responses with an empty or null body (#187)
- Never cache non-2xx upstream responses (#189)
- Enable the Guzzle `stream` option when `passage_streaming` is set (#191)
- Canonicalize nested query parameters in HMAC signing (#193)
- Disable response caching when streaming is enabled (#194)
- Default retry only on connection errors and 5xx responses (#195)
- Forward original `Content-Type` for JSON requests instead of rewriting to `application/json` (#196)
- Compare allowlisted hosts case-insensitively in `AllowedHostsGuard` (#197)
- Handle a missing upstream `Content-Type` header without a deprecation warning (#198)
- Exclude volatile headers from the response cache key (#199)
- Prevent `passage:health` from aborting when a handler throws (#200)
- Report unexpected exceptions from the proxy request path (#201)
- Report failure for `passage:health` routes with a missing or invalid handler class (#202)
- Validate the `--timeout` option to prevent CI hangs (#203)

## Change

- `composer.json`: `"version"` bumped from `v3.1.0` to `v3.1.1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017VELkBCcjWnbu1mXMATCYq)_