### PR TITLE
fix: match form-urlencoded Content-Type case-insensitively in PassageService

### DIFF
--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -51,7 +51,7 @@ class PassageService implements PassageServiceInterface
             return $this->dispatch($service, $method, $uri, $request->post(), 'multipart');
         }
 
-        if (str_contains($contentType, 'application/x-www-form-urlencoded')) {
+        if (str_contains(strtolower($contentType), 'application/x-www-form-urlencoded')) {
             // Forward the raw body verbatim instead of re-encoding $request->post()
             // via asForm(): the parsed array has already been url-decoded and, for
             // duplicate keys, collapsed to the last value, so re-encoding it can

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -76,6 +76,22 @@ describe('PassageService::callService()', function () {
             expect($this->service->callService($request, $pending, 'users'))->toBe($mockResponse);
         });
 
+        it('matches a non-lowercase form-urlencoded Content-Type case-insensitively', function () {
+            $body = 'name=Alice&role=admin';
+            $request = Request::create('/test', 'POST', [], [], [], [
+                'CONTENT_TYPE' => 'APPLICATION/X-WWW-FORM-URLENCODED',
+            ], $body);
+            $mockResponse = Mockery::mock(Response::class);
+            $pending = mockPending();
+            $pending->shouldReceive('withBody')
+                ->once()
+                ->with($body, 'APPLICATION/X-WWW-FORM-URLENCODED')
+                ->andReturn($pending);
+            $pending->shouldReceive('post')->once()->with('users')->andReturn($mockResponse);
+
+            expect($this->service->callService($request, $pending, 'users'))->toBe($mockResponse);
+        });
+
         it('sends JSON body with withBody() when Content-Type is application/json', function () {
             $body = json_encode(['name' => 'Alice']);
             $request = Request::create('/test', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], $body);


### PR DESCRIPTION
## What was broken

`PassageService::callService()` detected a form-urlencoded request body with a case-sensitive check:

```php
if (str_contains($contentType, 'application/x-www-form-urlencoded')) {
```

HTTP media types are case-insensitive per RFC 9110, and PHP populates `$_POST` from a form-urlencoded body regardless of the header's casing. If a client sent `Content-Type: APPLICATION/X-WWW-FORM-URLENCODED` (or any other non-canonical casing), this check missed it and the request silently fell through to the generic raw-body branch instead of the intended form-urlencoded handling path — diverging from the documented/tested behavior for lowercase Content-Type.

This is the same class of bug that was already fixed for the identical pattern in `HasHmacAuth::resolveHmacSignedBody()` (case-insensitive `multipart/form-data` detection), but the sibling check in `PassageService` was never updated to match.

## What changed

- `src/Services/PassageService.php`: lowercase the `Content-Type` header value before the `str_contains()` check, mirroring the existing `HasHmacAuth` fix.
- `tests/Unit/PassageServiceTest.php`: added a regression test asserting a non-lowercase form-urlencoded `Content-Type` is still forwarded via the form-urlencoded branch.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (199 passed, 537 assertions)

Fixes #182