### PR TITLE
Fix passage:health reporting success for routes with a missing base_uri

### DIFF
--- a/src/Commands/PassageHealthCommand.php
+++ b/src/Commands/PassageHealthCommand.php
@@ -65,7 +65,8 @@ class PassageHealthCommand extends Command
             $baseUri = $options['base_uri'] ?? null;
 
             if (! $baseUri) {
-                $rows[] = [$handler, $baseUri ?? '—', '<fg=yellow>SKIPPED</>', 'No base_uri configured'];
+                $rows[] = [class_basename($handler), '—', '<fg=red>FAIL</>', 'No base_uri configured'];
+                $anyFailed = true;
 
                 continue;
             }

--- a/tests/Unit/PassageHealthCommandTest.php
+++ b/tests/Unit/PassageHealthCommandTest.php
@@ -100,8 +100,22 @@ describe('PassageHealthCommand', function () {
         Passage::get('no-base-uri/{path?}', NoBaseUriHealthCommandPassageController::class);
 
         $this->artisan('passage:health')
-            ->expectsOutputToContain('SKIPPED')
-            ->assertExitCode(0);
+            ->expectsOutputToContain('No base_uri configured')
+            ->assertExitCode(1);
+    });
+
+    it('still checks other routes when a route has no base_uri configured', function () {
+        config()->set('passage.enabled', true);
+
+        Http::fake(['https://api.example.com' => Http::response('', 200)]);
+
+        Passage::get('no-base-uri/{path?}', NoBaseUriHealthCommandPassageController::class);
+        Passage::post('healthy/{path?}', HealthCommandTestPassageController::class);
+
+        $this->artisan('passage:health')
+            ->expectsOutputToContain('No base_uri configured')
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(1);
     });
 
     it('continues checking other routes when a handler cannot be resolved', function () {


### PR DESCRIPTION
## What was broken

`PassageHealthCommand` (`passage:health`) is documented as safe to run in CI pipelines and post-deployment checks. When a registered handler's `getOptions()` omits `base_uri`, the command marked the route as a neutral `SKIPPED` status and did not set `$anyFailed`, so the overall command still exited `0` (success).

A missing `base_uri` is not a "nothing to check" situation — it guarantees an `InvalidBaseUriException` on the very next real proxied request through that route. Reporting success here silently defeats the point of using `passage:health` as a deployment gate: a broken route can ship and the health check still comes back green.

## What changed

- `src/Commands/PassageHealthCommand.php`: routes with no `base_uri` configured are now reported as `FAIL` (instead of `SKIPPED`) and set `$anyFailed = true`, so the command exits `1` for them — consistent with how invalid/missing handler classes are already treated.
- `tests/Unit/PassageHealthCommandTest.php`: updated the existing coverage to assert the new `FAIL`/exit-code-1 behavior, and added a regression test confirming other routes are still checked (and reported `OK`) even when one route has no `base_uri` configured.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (200 tests, 540 assertions)

Fixes #177