### PR TITLE
fix: stream uploaded files instead of buffering them into memory

### DIFF
--- a/src/Concerns/HasHmacAuth.php
+++ b/src/Concerns/HasHmacAuth.php
@@ -123,7 +123,10 @@ trait HasHmacAuth
                 'name' => $singleFile->getClientOriginalName(),
                 'size' => $singleFile->getSize(),
                 'mime' => $singleFile->getMimeType(),
-                'hash' => hash('sha256', $singleFile->get()),
+                // Hash from disk rather than $singleFile->get(), which reads
+                // the entire file into memory at once — a large upload would
+                // otherwise risk exhausting a PHP-FPM worker's memory limit.
+                'hash' => hash_file('sha256', $singleFile->getRealPath()),
             ];
         }
 

--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -40,9 +40,12 @@ class PassageService implements PassageServiceInterface
         // dropped into the raw-passthrough branch below with no body.
         if (count($request->allFiles()) > 0 || str_contains(strtolower($contentType), 'multipart/form-data')) {
             foreach (NestedFileResolver::flatten($request->allFiles()) as $key => $singleFile) {
+                // Stream from disk instead of $singleFile->get(), which reads
+                // the entire file into memory at once — a large upload would
+                // otherwise risk exhausting a PHP-FPM worker's memory limit.
                 $service = $service->attach(
                     $key,
-                    $singleFile->get(),
+                    fopen($singleFile->getRealPath(), 'r'),
                     $singleFile->getClientOriginalName(),
                     ['Content-Type' => $singleFile->getMimeType()]
                 );

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -280,7 +280,7 @@ describe('PassageService::callService()', function () {
     });
 
     describe('file uploads', function () {
-        it('forwards a single uploaded file', function () {
+        it('forwards a single uploaded file as a stream instead of buffering it into memory', function () {
             $file = UploadedFile::fake()->create('avatar.png', 10, 'image/png');
             $request = Request::create('/test', 'POST');
             $request->files->set('avatar', $file);
@@ -289,7 +289,11 @@ describe('PassageService::callService()', function () {
             $pending = mockPending();
             $pending->shouldReceive('attach')
                 ->once()
-                ->with('avatar', $file->get(), 'avatar.png', ['Content-Type' => 'image/png'])
+                ->withArgs(fn ($name, $contents, $filename, $headers) => $name === 'avatar'
+                    && is_resource($contents)
+                    && stream_get_contents($contents) === $file->get()
+                    && $filename === 'avatar.png'
+                    && $headers === ['Content-Type' => 'image/png'])
                 ->andReturn($pending);
             $pending->shouldReceive('post')->once()->with('upload', [])->andReturn($mockResponse);
 
@@ -306,11 +310,19 @@ describe('PassageService::callService()', function () {
             $pending = mockPending();
             $pending->shouldReceive('attach')
                 ->once()
-                ->with('attachments[0]', $file1->get(), 'one.txt', ['Content-Type' => 'text/plain'])
+                ->withArgs(fn ($name, $contents, $filename, $headers) => $name === 'attachments[0]'
+                    && is_resource($contents)
+                    && stream_get_contents($contents) === $file1->get()
+                    && $filename === 'one.txt'
+                    && $headers === ['Content-Type' => 'text/plain'])
                 ->andReturn($pending);
             $pending->shouldReceive('attach')
                 ->once()
-                ->with('attachments[1]', $file2->get(), 'two.txt', ['Content-Type' => 'text/plain'])
+                ->withArgs(fn ($name, $contents, $filename, $headers) => $name === 'attachments[1]'
+                    && is_resource($contents)
+                    && stream_get_contents($contents) === $file2->get()
+                    && $filename === 'two.txt'
+                    && $headers === ['Content-Type' => 'text/plain'])
                 ->andReturn($pending);
             $pending->shouldReceive('post')->once()->with('upload', [])->andReturn($mockResponse);
 
@@ -326,7 +338,11 @@ describe('PassageService::callService()', function () {
             $pending = mockPending();
             $pending->shouldReceive('attach')
                 ->once()
-                ->with('docs[0][avatar]', $file->get(), 'avatar.png', ['Content-Type' => 'image/png'])
+                ->withArgs(fn ($name, $contents, $filename, $headers) => $name === 'docs[0][avatar]'
+                    && is_resource($contents)
+                    && stream_get_contents($contents) === $file->get()
+                    && $filename === 'avatar.png'
+                    && $headers === ['Content-Type' => 'image/png'])
                 ->andReturn($pending);
             $pending->shouldReceive('post')->once()->with('upload', [])->andReturn($mockResponse);
 


### PR DESCRIPTION
## What was broken

Two separate code paths read an entire uploaded file into a PHP string via `UploadedFile::get()` before forwarding it upstream, instead of streaming it:

- `src/Concerns/HasHmacAuth.php` (`resolveHmacSignedBody()`) — hashed the file content with `hash('sha256', $singleFile->get())` to build the HMAC-signed payload.
- `src/Services/PassageService.php` (`callService()`) — attached the file content directly with `$singleFile->get()` when forwarding multipart requests.

For a handler that combines the `HasHmacAuth` trait with a file-upload endpoint, a single request would fully load the same uploaded file into memory twice. This risks memory exhaustion on typical PHP-FPM worker memory limits for large uploads, and is inconsistent with the package's own streaming-response feature (`PassageResponseBuilder::buildStreamedResponse()`), which exists specifically to avoid buffering large payloads.

## What changed

- `HasHmacAuth::resolveHmacSignedBody()` now hashes the file directly from disk with `hash_file('sha256', $singleFile->getRealPath())` instead of reading its full contents into memory first.
- `PassageService::callService()` now attaches a file stream (`fopen($singleFile->getRealPath(), 'r')`) to the outbound multipart request instead of the fully-read file contents, relying on Guzzle's multipart streaming support.
- Updated the existing file-upload tests in `tests/Unit/PassageServiceTest.php` to assert that `attach()` receives a readable stream resource whose contents match the original file, rather than asserting on the raw string content.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — 200 tests passed (540 assertions)

Fixes #160