### PR TITLE
Validate handler name in passage:controller before use

### DIFF
--- a/src/Commands/PassageCommand.php
+++ b/src/Commands/PassageCommand.php
@@ -24,6 +24,12 @@ class PassageCommand extends Command
         $withCache = $this->option('with-cache');
         $withRetry = $this->option('with-retry');
 
+        if (! preg_match('/^[A-Za-z0-9_\/]+$/', $name)) {
+            $this->error("Invalid handler name [{$name}]: only letters, numbers, underscores, and slashes are allowed.");
+
+            return self::FAILURE;
+        }
+
         if (file_exists(app_path('Http/Controllers/Passages/'.$name.'.php'))) {
             $this->error("Passage handler {$name} already exists at app/Http/Controllers/Passages/{$name}.php");
 

--- a/tests/Unit/PassageCommandTest.php
+++ b/tests/Unit/PassageCommandTest.php
@@ -90,4 +90,18 @@ describe('PassageCommand', function () {
             ->expectsOutputToContain('already exists')
             ->assertExitCode(1);
     });
+
+    it('rejects a handler name containing path traversal segments', function () {
+        $this->artisan('passage:controller ../../../../tmp/evil')
+            ->expectsOutputToContain('Invalid handler name')
+            ->assertExitCode(1);
+
+        expect(File::exists(app_path('Http/Controllers/Passages/evil.php')))->toBeFalse();
+    });
+
+    it('rejects a handler name containing unexpected characters', function () {
+        $this->artisan('passage:controller "Evil; rm -rf /"')
+            ->expectsOutputToContain('Invalid handler name')
+            ->assertExitCode(1);
+    });
 });


### PR DESCRIPTION
## What was broken

`passage:controller`'s `name` argument was interpolated directly into a filesystem path check and into the string passed to `Artisan::call()`, with no validation against path-traversal sequences (`../`) or other unexpected characters:

```php
$name = $this->argument('name');
...
if (file_exists(app_path('Http/Controllers/Passages/'.$name.'.php'))) {
    ...
}
...
Artisan::call("make:controller Passages/{$name} --type=passage{$stubType}");
```

A value like `passage:controller ../../../../tmp/evil` would have `file_exists()` probe a path outside the intended `app/Http/Controllers/Passages/` directory, and the resulting `Artisan::call()` string would depend entirely on Laravel's own `make:controller` path resolution — behavior this package doesn't control or validate against. This mirrors a security concern the codebase already treats seriously elsewhere (see `PassageController::containsDotSegment()`, which guards proxied request paths against the same class of issue).

## What changed

- `src/Commands/PassageCommand.php`: validate `$name` against a safe pattern (`^[A-Za-z0-9_\/]+$`) before it's used in either the filesystem check or the `Artisan::call()` string. Invalid input now fails fast with a clear error message and `self::FAILURE`, instead of reaching the filesystem or Artisan.
- `tests/Unit/PassageCommandTest.php`: added regression tests covering a path-traversal name and a name with shell-metacharacter-like content, asserting both are rejected and no file is created.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` — full suite passes (202 tests, 545 assertions)

Fixes #135