### PR TITLE
Share a single hop-by-hop header fallback list between request and response paths

### DIFF
--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -4,18 +4,12 @@ namespace Morcen\Passage\Http;
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\JsonResponse;
+use Morcen\Passage\Support\ForwardedHeaderResolver;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PassageResponseBuilder
 {
-    // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
-    private const HOP_BY_HOP_FALLBACK = [
-        'host', 'connection', 'transfer-encoding', 'upgrade',
-        'keep-alive', 'te', 'trailer', 'proxy-authenticate',
-        'proxy-authorization',
-    ];
-
     // Guzzle's default `decode_content` option transparently decompresses gzip/deflate/br
     // bodies (Passage never disables it), but leaves Content-Encoding/Content-Length on the
     // response describing the discarded compressed representation. Relaying them verbatim
@@ -78,7 +72,7 @@ class PassageResponseBuilder
 
     private function resolveResponseHeaders(Response $upstream): array
     {
-        $hopByHop = config('passage.security.hop_by_hop_headers', self::HOP_BY_HOP_FALLBACK);
+        $hopByHop = config('passage.security.hop_by_hop_headers', ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK);
         $headers = [];
 
         foreach ($upstream->headers() as $name => $values) {

--- a/src/Support/ForwardedHeaderResolver.php
+++ b/src/Support/ForwardedHeaderResolver.php
@@ -16,9 +16,11 @@ use Illuminate\Http\Request;
 class ForwardedHeaderResolver
 {
     // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
-    private const HOP_BY_HOP_FALLBACK = [
+    // Public so PassageResponseBuilder can share it instead of maintaining its own copy.
+    public const HOP_BY_HOP_FALLBACK = [
         'host', 'connection', 'transfer-encoding', 'upgrade',
         'keep-alive', 'te', 'trailer', 'proxy-authenticate',
+        'proxy-authorization',
     ];
 
     public static function resolve(Request $request): array

--- a/tests/Unit/ForwardedHeaderResolverTest.php
+++ b/tests/Unit/ForwardedHeaderResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Http\Request;
+use Morcen\Passage\Support\ForwardedHeaderResolver;
+
+describe('ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK', function () {
+    it('matches the published config default for hop_by_hop_headers', function () {
+        expect(ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK)
+            ->toBe(config('passage.security.hop_by_hop_headers'));
+    });
+
+    it('includes proxy-authorization, since it is also a hop-by-hop header', function () {
+        expect(ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK)->toContain('proxy-authorization');
+    });
+});
+
+describe('ForwardedHeaderResolver::resolve()', function () {
+    it('strips Proxy-Authorization from the forwarded request when config is unavailable', function () {
+        $security = config('passage.security');
+        unset($security['hop_by_hop_headers']);
+        config(['passage.security' => $security]);
+
+        $request = Request::create('/test', 'GET');
+        $request->headers->set('Proxy-Authorization', 'Basic secret-credentials');
+        $request->headers->set('X-Custom', 'keep-me');
+
+        $headers = ForwardedHeaderResolver::resolve($request);
+
+        expect($headers)->not->toHaveKey('Proxy-Authorization');
+        expect($headers)->toHaveKey('X-Custom');
+    });
+});


### PR DESCRIPTION
## What was broken

`ForwardedHeaderResolver` (request path — headers stripped before forwarding the client's request upstream) and `PassageResponseBuilder` (response path — headers stripped before returning the upstream's response to the client) each maintained their own independent `HOP_BY_HOP_FALLBACK` constant. Both are only consulted when `passage.security.hop_by_hop_headers` config is unavailable (e.g. early bootstrap).

The two lists had already drifted: the response-side list included `proxy-authorization`, the request-side one did not. If the config were ever unavailable on the request path — exactly the scenario the fallback exists to protect against — a client-supplied or handler-injected `Proxy-Authorization` header would be forwarded upstream unfiltered.

## What changed

- `ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK` is now `public` and is the single source of truth, with `proxy-authorization` added so it matches the published config default in `config/passage.php`.
- `PassageResponseBuilder` no longer keeps its own copy — it reuses `ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK` — so there is exactly one list to keep in sync going forward.
- Added `tests/Unit/ForwardedHeaderResolverTest.php`, asserting the fallback constant matches the config default and that `Proxy-Authorization` is stripped from the forwarded request when config is unavailable.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` — 205 passed (549 assertions)

Fixes #167