### PR TITLE
fix: resolve passage:list handler targets through the container

### DIFF
--- a/src/Commands/PassageListCommand.php
+++ b/src/Commands/PassageListCommand.php
@@ -58,7 +58,7 @@ class PassageListCommand extends Command
         }
 
         try {
-            $instance = new $handler;
+            $instance = app($handler);
             $options = $instance->getOptions();
         } catch (Throwable) {
             return $handler.' (could not resolve target)';

--- a/tests/Unit/PassageListCommandTest.php
+++ b/tests/Unit/PassageListCommandTest.php
@@ -23,6 +23,34 @@ class ListCommandTestPassageController implements PassageControllerInterface
     }
 }
 
+class ListCommandDependency
+{
+    public function baseUri(): string
+    {
+        return 'https://api.example.com';
+    }
+}
+
+class DependentListCommandPassageController implements PassageControllerInterface
+{
+    public function __construct(private ListCommandDependency $dependency) {}
+
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => $this->dependency->baseUri()];
+    }
+}
+
 class ThrowingListCommandPassageController implements PassageControllerInterface
 {
     public function getRequest(Request $request): Request
@@ -79,6 +107,19 @@ describe('PassageListCommand', function () {
 
         $this->artisan('passage:list')
             ->expectsOutputToContain('github/{path?}')
+            ->assertExitCode(0);
+    });
+
+    it('resolves handlers with constructor dependencies through the container', function () {
+        config()->set('passage.enabled', true);
+
+        Passage::get('dependent/{path?}', DependentListCommandPassageController::class);
+
+        $this->artisan('passage:list')
+            ->expectsTable(
+                ['Method', 'URI', 'Target'],
+                [['GET|HEAD', 'dependent/{path?}', 'https://api.example.com ('.DependentListCommandPassageController::class.')']]
+            )
             ->assertExitCode(0);
     });
 


### PR DESCRIPTION
## What was broken

`PassageListCommand::resolveTarget()` instantiated handler classes directly with `new $handler`:

```php
$instance = new $handler;
$options = $instance->getOptions();
```

This is inconsistent with every other place that resolves a Passage handler, which all go through the Laravel container:

- `PassageHealthCommand` — `app($handler)` (`src/Commands/PassageHealthCommand.php:56`)
- `PassageController` (the real proxy path) — `$this->app->make($handler)` (`src/Http/Controllers/PassageController.php`)

Nothing in `PassageControllerInterface` forbids constructor-injected dependencies, and constructor injection is the standard, encouraged Laravel pattern. As a result, any handler with a required constructor argument (a config repository, an HTTP client, any injected service) works correctly when actually proxying requests and when health-checked, but `passage:list` throws inside its `try` block on `new $handler` and silently falls back to printing `"$handler (could not resolve target)"` instead of the handler's real `base_uri` — a confusing, misleading failure in a command whose entire purpose is to let developers audit which routes are proxied.

## What changed

- `src/Commands/PassageListCommand.php` — replaced `new $handler` with `app($handler)`, so handlers are resolved through the container exactly like the sibling command and the request-handling path.
- `tests/Unit/PassageListCommandTest.php` — added a regression test with a handler that has a required constructor dependency, asserting `passage:list` reports its real `base_uri` rather than `(could not resolve target)`.

## Testing

- Full suite passes: `206 passed (555 assertions)`.
- `vendor/bin/pint --dirty` reports clean.

Fixes #131