### PR TITLE
fix: match passage:list routes by fully-qualified controller name

### DIFF
--- a/src/Commands/PassageListCommand.php
+++ b/src/Commands/PassageListCommand.php
@@ -28,7 +28,7 @@ class PassageListCommand extends Command
 
         foreach (Route::getRoutes() as $route) {
             $uses = $route->getAction('uses');
-            if (! is_string($uses) || ! str_contains($uses, class_basename(PassageController::class).'@handle')) {
+            if (! is_string($uses) || ! str_contains($uses, PassageController::class.'@handle')) {
                 continue;
             }
 

--- a/tests/Unit/PassageListCommandTest.php
+++ b/tests/Unit/PassageListCommandTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 use Morcen\Passage\Facades\Passage;
 use Morcen\Passage\PassageControllerInterface;
 
@@ -69,6 +70,19 @@ class ThrowingListCommandPassageController implements PassageControllerInterface
     }
 }
 
+// An app-namespaced controller that happens to share the short class name
+// "PassageController" with Morcen\Passage\Http\Controllers\PassageController,
+// including its own unrelated "handle" method. Used to prove passage:list
+// only matches the package's fully-qualified controller, not a same-named
+// class defined by the host application.
+class PassageController
+{
+    public function handle(): string
+    {
+        return 'not a Passage route';
+    }
+}
+
 describe('PassageListCommand', function () {
     it('warns when passage is disabled', function () {
         config()->set('passage.enabled', false);
@@ -119,6 +133,20 @@ describe('PassageListCommand', function () {
             ->expectsTable(
                 ['Method', 'URI', 'Target'],
                 [['GET|HEAD', 'dependent/{path?}', 'https://api.example.com ('.DependentListCommandPassageController::class.')']]
+            )
+            ->assertExitCode(0);
+    });
+
+    it('does not list an app route whose controller merely shares the short class name "PassageController"', function () {
+        config()->set('passage.enabled', true);
+
+        Passage::get('github/{path?}', ListCommandTestPassageController::class);
+        Route::get('unrelated/{path?}', [PassageController::class, 'handle']);
+
+        $this->artisan('passage:list')
+            ->expectsTable(
+                ['Method', 'URI', 'Target'],
+                [['GET|HEAD', 'github/{path?}', 'https://api.github.com ('.ListCommandTestPassageController::class.')']]
             )
             ->assertExitCode(0);
     });


### PR DESCRIPTION
## What was broken

`PassageListCommand::handle()` identified Passage routes with a substring match against the *short* class name:

```php
if (! is_string($uses) || ! str_contains($uses, class_basename(PassageController::class).'@handle')) {
    continue;
}
```

`class_basename(PassageController::class)` is just `'PassageController'`. Since the check is a plain `str_contains()` against `'PassageController@handle'`, any host-application route whose action string happens to end in `...PassageController@handle` — for example an app-defined `App\Http\Controllers\Api\PassageController` with its own unrelated `handle()` method — would be incorrectly reported as a Passage proxy route by `php artisan passage:list`.

`PassageHealthCommand::passageRoutes()` already avoids this by matching against the fully-qualified class name (`PassageController::class.'@handle'`), so `PassageListCommand` was the odd one out.

Because `passage:list` exists specifically to let operators audit which routes are actually proxied by this package, a false positive here could mislead a route or security audit — showing an unrelated, package-external route as a Passage proxy target.

## What changed

- `src/Commands/PassageListCommand.php`: match routes against the fully-qualified `PassageController::class.'@handle'` instead of the short class name, matching the approach already used in `PassageHealthCommand`.
- `tests/Unit/PassageListCommandTest.php`: added a regression test registering a plain Laravel route on an app-namespaced class that shares the short name `PassageController` (with its own `handle()` method), asserting it is not listed alongside genuine Passage routes.

Fixes #138