### PR TITLE
fix: passage:list returns success exit code when Passage is disabled

### DIFF
--- a/src/Commands/PassageListCommand.php
+++ b/src/Commands/PassageListCommand.php
@@ -21,7 +21,7 @@ class PassageListCommand extends Command
         if (! (config('passage.enabled') ?? true)) {
             $this->warn('Passage is disabled. Set PASSAGE_ENABLED=true to enable it.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         $rows = [];

--- a/tests/Unit/PassageListCommandTest.php
+++ b/tests/Unit/PassageListCommandTest.php
@@ -89,7 +89,7 @@ describe('PassageListCommand', function () {
 
         $this->artisan('passage:list')
             ->expectsOutputToContain('Passage is disabled')
-            ->assertExitCode(1);
+            ->assertExitCode(0);
     });
 
     it('warns when no Passage routes are registered', function () {


### PR DESCRIPTION
## What was broken

`passage.enabled => false` (`PASSAGE_ENABLED=false`) is a documented, intentional configuration state, not an error. `passage:health` and `PassageController` both treat it that way: they warn (or return a normal 404) and exit successfully. `passage:list` was the odd one out — it returned `self::FAILURE` (exit code 1) for the exact same condition, even though the existing test explicitly asserted that wrong behavior.

This breaks automated tooling: any CI or deploy script that runs `php artisan passage:list` for visibility fails the moment an operator disables Passage via `PASSAGE_ENABLED=false` for troubleshooting, even though nothing is actually broken.

## What changed

- `src/Commands/PassageListCommand.php`: return `self::SUCCESS` (instead of `self::FAILURE`) when Passage is disabled, matching `PassageHealthCommand`'s behavior.
- `tests/Unit/PassageListCommandTest.php`: updated the existing "warns when passage is disabled" test to assert exit code `0` instead of `1`.

Fixes #126