### PR TITLE
Fix passage:controller reporting success when make:controller fails

### DIFF
--- a/src/Commands/PassageCommand.php
+++ b/src/Commands/PassageCommand.php
@@ -37,7 +37,18 @@ class PassageCommand extends Command
         }
 
         $stubType = $this->resolveStubType($authStyle, $withCache, $withRetry);
-        Artisan::call("make:controller Passages/{$name} --type=passage{$stubType}");
+        $exitCode = Artisan::call("make:controller Passages/{$name} --type=passage{$stubType}");
+
+        if ($exitCode !== self::SUCCESS) {
+            $this->error("Failed to create passage handler {$name}.");
+
+            $output = trim(Artisan::output());
+            if ($output !== '') {
+                $this->line($output);
+            }
+
+            return self::FAILURE;
+        }
 
         $this->info("Passage handler created at app/Http/Controllers/Passages/{$name}.php");
         $this->newLine();

--- a/tests/Unit/PassageCommandTest.php
+++ b/tests/Unit/PassageCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Support\Facades\File;
 
 describe('PassageCommand', function () {
@@ -103,5 +105,65 @@ describe('PassageCommand', function () {
         $this->artisan('passage:controller "Evil; rm -rf /"')
             ->expectsOutputToContain('Invalid handler name')
             ->assertExitCode(1);
+    });
+
+    it('fails and relays output when the underlying make:controller call fails', function () {
+        $realKernel = app(ConsoleKernelContract::class);
+
+        // Orchestra\Testbench\Console\Kernel is final, so it can't be mocked directly.
+        // Decorate it instead: intercept the nested make:controller call and delegate
+        // everything else (including the outer passage:controller invocation) as-is.
+        $fakeKernel = new class($realKernel) implements ConsoleKernelContract
+        {
+            public function __construct(private ConsoleKernelContract $kernel) {}
+
+            public function call($command, array $parameters = [], $outputBuffer = null)
+            {
+                if (str_starts_with($command, 'make:controller Passages/FailingHandler')) {
+                    return Command::FAILURE;
+                }
+
+                return $this->kernel->call($command, $parameters, $outputBuffer);
+            }
+
+            public function output()
+            {
+                return 'Controller already exists.';
+            }
+
+            public function bootstrap()
+            {
+                return $this->kernel->bootstrap();
+            }
+
+            public function handle($input, $output = null)
+            {
+                return $this->kernel->handle($input, $output);
+            }
+
+            public function queue($command, array $parameters = [])
+            {
+                return $this->kernel->queue($command, $parameters);
+            }
+
+            public function all()
+            {
+                return $this->kernel->all();
+            }
+
+            public function terminate($input, $status)
+            {
+                return $this->kernel->terminate($input, $status);
+            }
+        };
+
+        app()->instance(ConsoleKernelContract::class, $fakeKernel);
+
+        $this->artisan('passage:controller FailingHandler')
+            ->expectsOutputToContain('Failed to create passage handler FailingHandler.')
+            ->expectsOutputToContain('Controller already exists.')
+            ->assertExitCode(1);
+
+        expect(File::exists(app_path('Http/Controllers/Passages/FailingHandler.php')))->toBeFalse();
     });
 });


### PR DESCRIPTION
## What was broken

`PassageCommand::handle()` (the `passage:controller` Artisan command) called the nested `make:controller` command via `Artisan::call()` but ignored its return value:

```php
Artisan::call("make:controller Passages/{$name} --type=passage{$stubType}");

$this->info("Passage handler created at app/Http/Controllers/Passages/{$name}.php");
```

If the inner `make:controller` call failed for any non-throwing reason (e.g. an unwritable `app/Http/Controllers/Passages/` directory, a disk-full condition, or an unresolvable stub), the command still unconditionally printed the success message, discarded the generator's actual error output, and returned `self::SUCCESS`. A user (or a CI script relying on the exit code) had no way to know the file was never written, and would be shown misleading follow-up instructions referencing a class that doesn't exist.

## What changed

- Capture the exit code returned by `Artisan::call('make:controller ...')`.
- When it's not `self::SUCCESS`, print an error message, relay the inner command's captured output (`Artisan::output()`) for context, and return `self::FAILURE` instead of continuing.
- Added a Pest test that exercises this failure path. Since Testbench's console kernel is `final` and can't be mocked directly, the test decorates the bound `Illuminate\Contracts\Console\Kernel` to intercept only the nested `make:controller` call while delegating everything else (including the outer `passage:controller` invocation) to the real kernel.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` (full suite) — 208 passed

Fixes #148