### PR TITLE
fix: PassageEventSubscriber falls back to default log channel when unconfigured

### DIFF
--- a/src/Listeners/PassageEventSubscriber.php
+++ b/src/Listeners/PassageEventSubscriber.php
@@ -68,6 +68,6 @@ class PassageEventSubscriber
 
     private function channel(): string
     {
-        return 'passage';
+        return config('logging.channels.passage') ? 'passage' : config('logging.default', 'stack');
     }
 }

--- a/tests/Unit/PassageEventSubscriberTest.php
+++ b/tests/Unit/PassageEventSubscriberTest.php
@@ -10,6 +10,13 @@ use Morcen\Passage\Events\PassageResponseReceived;
 use Morcen\Passage\Listeners\PassageEventSubscriber;
 
 describe('PassageEventSubscriber', function () {
+    beforeEach(function () {
+        config()->set('logging.channels.passage', [
+            'driver' => 'single',
+            'path' => storage_path('logs/passage.log'),
+        ]);
+    });
+
     it('logs a debug message when a request is sending', function () {
         $request = Request::create('/proxy/users', 'POST');
         $event = new PassageRequestSending(
@@ -83,5 +90,26 @@ describe('PassageEventSubscriber', function () {
             ]);
 
         (new PassageEventSubscriber)->onRequestFailed($event);
+    });
+
+    it('falls back to the default log channel when no passage channel is configured', function () {
+        config()->set('logging.channels.passage', null);
+        config()->set('logging.default', 'stack');
+
+        $request = Request::create('/proxy/users', 'POST');
+        $event = new PassageRequestSending(
+            $request,
+            'App\\Http\\Controllers\\Passages\\UsersHandler',
+            'https://api.example.com/users',
+            microtime(true),
+        );
+
+        Log::shouldReceive('channel')
+            ->once()
+            ->with('stack')
+            ->andReturnSelf();
+        Log::shouldReceive('debug')->once();
+
+        (new PassageEventSubscriber)->onRequestSending($event);
     });
 });


### PR DESCRIPTION
## What was broken

`PassageEventSubscriber`'s docblock documents that it "logs to the 'passage' channel if configured, otherwise falls back to the default channel." The code didn't do that: `channel()` unconditionally returned the literal string `'passage'`, with no fallback.

In practice, any consuming application that registers `PassageEventSubscriber` without also publishing a dedicated `passage` channel in `config/logging.php` ends up routing every Passage log entry (request sending, response received, request failed) through Laravel's emergency logger instead of its configured default channel — silently diverging from what the class's own documentation promises, and making Passage's request/response/failure logs easy to lose track of.

## What changed

- `src/Listeners/PassageEventSubscriber.php`: `channel()` now checks whether `logging.channels.passage` is configured and returns `'passage'` in that case, otherwise falls back to `config('logging.default', 'stack')` — matching the existing docblock.
- `tests/Unit/PassageEventSubscriberTest.php`: the existing tests now configure a `passage` log channel (since that's what they're exercising), and a new test asserts the fallback: `it falls back to the default log channel when no passage channel is configured`.

## Testing

- `vendor/bin/pint --dirty` — passed, no changes needed.
- `vendor/bin/pest` — full suite passes: 209 passed (567 assertions).

Fixes #93