### PR TITLE
fix: add X-Forwarded-* headers to upstream requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ To change which headers are stripped globally, edit `config/passage.php`:
 ],
 ```
 
+### Forwarded headers
+
+Passage strips the client's `Host` header (it's hop-by-hop) and calls upstream from the gateway's own IP, so by default an upstream service has no way to see the original client's address, host, or scheme — which breaks per-client rate limiting, geo logic, and audit logging behind the proxy.
+
+To fix this, Passage adds standard `X-Forwarded-*` headers to every outbound request:
+
+- `X-Forwarded-For`: the client's IP, appended to any existing chain
+- `X-Forwarded-Host`: the original `Host` the client requested
+- `X-Forwarded-Proto`: the original request scheme (`http`/`https`)
+
+This is enabled by default. Disable it for deployments that should not reveal client IPs to upstream services:
+
+```env
+PASSAGE_ADD_FORWARDED_HEADERS=false
+```
+
 ### Forwarding a client header on a specific route
 
 If a route legitimately needs to forward a specific client header (for example, forwarding a client's `Authorization` to an upstream that validates it), implement `AcceptsClientHeaders` on the handler:

--- a/config/passage.php
+++ b/config/passage.php
@@ -86,6 +86,15 @@ return [
         'strip_client_headers' => ['cookie', 'authorization', 'proxy-authorization'],
 
         /*
+        | When true, Passage adds X-Forwarded-For, X-Forwarded-Host, and
+        | X-Forwarded-Proto headers to the outbound request so upstream
+        | services see the original client's IP, host, and scheme instead
+        | of the gateway's. Disable for deployments that should not reveal
+        | client IPs to upstream services.
+        */
+        'add_forwarded_headers' => env('PASSAGE_ADD_FORWARDED_HEADERS', true),
+
+        /*
         | Hop-by-hop headers are always stripped and cannot be configured.
         | These are transport-level headers that must not be forwarded by
         | any proxy (RFC 7230).

--- a/src/Services/PassageService.php
+++ b/src/Services/PassageService.php
@@ -13,7 +13,16 @@ class PassageService implements PassageServiceInterface
     public function callService(Request $request, PendingRequest $service, string $uri): Response
     {
         $method = strtolower($request->method());
-        $service = $service->withHeaders(ForwardedHeaderResolver::resolve($request));
+        $headers = ForwardedHeaderResolver::resolve($request);
+
+        if (config('passage.security.add_forwarded_headers', true)) {
+            // Merged after resolve() so an authoritative, correctly-chained
+            // value wins over anything the client itself sent under the
+            // same header name.
+            $headers = array_merge($headers, ForwardedHeaderResolver::forwardedHeaders($request));
+        }
+
+        $service = $service->withHeaders($headers);
 
         if (in_array($method, ['get', 'head'])) {
             return $service->{$method}($uri, $request->query());

--- a/src/Support/ForwardedHeaderResolver.php
+++ b/src/Support/ForwardedHeaderResolver.php
@@ -40,4 +40,25 @@ class ForwardedHeaderResolver
 
         return $headers;
     }
+
+    /**
+     * Standard proxy headers that tell the upstream service about the
+     * original client, since Passage's own Host header is stripped as
+     * hop-by-hop and the upstream otherwise only ever sees the gateway's
+     * IP, host, and scheme. This breaks per-client rate limiting, geo
+     * logic, and audit logging on services behind Passage.
+     *
+     * Appends to an existing X-Forwarded-For chain (e.g. one set by an
+     * upstream load balancer) rather than replacing it, per convention.
+     */
+    public static function forwardedHeaders(Request $request): array
+    {
+        $chain = array_filter([$request->header('X-Forwarded-For'), $request->ip()]);
+
+        return [
+            'X-Forwarded-For' => implode(', ', $chain),
+            'X-Forwarded-Host' => $request->getHost(),
+            'X-Forwarded-Proto' => $request->getScheme(),
+        ];
+    }
 }

--- a/tests/Unit/ForwardedHeaderResolverTest.php
+++ b/tests/Unit/ForwardedHeaderResolverTest.php
@@ -30,3 +30,38 @@ describe('ForwardedHeaderResolver::resolve()', function () {
         expect($headers)->toHaveKey('X-Custom');
     });
 });
+
+describe('ForwardedHeaderResolver::forwardedHeaders()', function () {
+    it('sets X-Forwarded-For to the client IP when no chain exists yet', function () {
+        $request = Request::create('/test', 'GET', server: ['REMOTE_ADDR' => '203.0.113.5']);
+
+        $headers = ForwardedHeaderResolver::forwardedHeaders($request);
+
+        expect($headers['X-Forwarded-For'])->toBe('203.0.113.5');
+    });
+
+    it('appends the client IP to an existing X-Forwarded-For chain instead of replacing it', function () {
+        $request = Request::create('/test', 'GET', server: ['REMOTE_ADDR' => '203.0.113.5']);
+        $request->headers->set('X-Forwarded-For', '198.51.100.1');
+
+        $headers = ForwardedHeaderResolver::forwardedHeaders($request);
+
+        expect($headers['X-Forwarded-For'])->toBe('198.51.100.1, 203.0.113.5');
+    });
+
+    it('sets X-Forwarded-Host to the original request host', function () {
+        $request = Request::create('http://gateway.example.com/test', 'GET');
+
+        $headers = ForwardedHeaderResolver::forwardedHeaders($request);
+
+        expect($headers['X-Forwarded-Host'])->toBe('gateway.example.com');
+    });
+
+    it('sets X-Forwarded-Proto to the request scheme', function () {
+        $request = Request::create('https://gateway.example.com/test', 'GET');
+
+        $headers = ForwardedHeaderResolver::forwardedHeaders($request);
+
+        expect($headers['X-Forwarded-Proto'])->toBe('https');
+    });
+});

--- a/tests/Unit/PassageServiceTest.php
+++ b/tests/Unit/PassageServiceTest.php
@@ -258,13 +258,48 @@ describe('PassageService::callService()', function () {
             $this->service->callService($request, $pending, 'test');
         });
 
+        it('adds X-Forwarded-* headers so upstream sees the original client', function () {
+            $request = Request::create('http://gateway.example.com/test', 'GET', server: ['REMOTE_ADDR' => '203.0.113.5']);
+
+            $pending = Mockery::mock(PendingRequest::class);
+            $pending->shouldReceive('withHeaders')
+                ->once()
+                ->withArgs(fn (array $h) => ($h['X-Forwarded-For'] ?? null) === '203.0.113.5'
+                    && ($h['X-Forwarded-Host'] ?? null) === 'gateway.example.com'
+                    && ($h['X-Forwarded-Proto'] ?? null) === 'http')
+                ->andReturn($pending);
+            $pending->shouldReceive('get')->andReturn(Mockery::mock(Response::class));
+
+            $this->service->callService($request, $pending, 'test');
+        });
+
+        it('does not add X-Forwarded-* headers when add_forwarded_headers is disabled', function () {
+            config(['passage.security.add_forwarded_headers' => false]);
+
+            $request = Request::create('http://gateway.example.com/test', 'GET', server: ['REMOTE_ADDR' => '203.0.113.5']);
+
+            $pending = Mockery::mock(PendingRequest::class);
+            $pending->shouldReceive('withHeaders')
+                ->once()
+                ->withArgs(fn (array $h) => ! array_key_exists('X-Forwarded-For', $h)
+                    && ! array_key_exists('X-Forwarded-Host', $h)
+                    && ! array_key_exists('X-Forwarded-Proto', $h))
+                ->andReturn($pending);
+            $pending->shouldReceive('get')->andReturn(Mockery::mock(Response::class));
+
+            $this->service->callService($request, $pending, 'test');
+        });
+
         it('normalizes all-uppercase header names before forwarding', function () {
             $request = Request::create('/test', 'GET');
             $request->headers = new class extends HeaderBag
             {
                 public function all(?string $key = null): array
                 {
-                    return ['AUTHORIZATION' => ['Bearer service-token']];
+                    // Only override the parameterless call ForwardedHeaderResolver::resolve()
+                    // makes to iterate every header; a specific $key (e.g. from
+                    // Request::header()) still needs real HeaderBag lookup behavior.
+                    return $key === null ? ['AUTHORIZATION' => ['Bearer service-token']] : parent::all($key);
                 }
             };
 


### PR DESCRIPTION
## What was broken

Passage strips the client's `Host` header (correctly, since it's hop-by-hop) and calls upstream from the gateway's own IP. As a result, upstream services had no way to see the original client's IP, host, or scheme — every request looked like it came from the gateway. This breaks per-client rate limiting, geo logic, and audit logging on any service behind Passage.

## What changed

- `ForwardedHeaderResolver::forwardedHeaders()`: a new method that builds the standard `X-Forwarded-For` (appended to any existing chain), `X-Forwarded-Host`, and `X-Forwarded-Proto` headers from the inbound request.
- `PassageService::callService()`: merges these headers into the outbound request, gated by a new config flag so they only affect the actual upstream call — not the headers `PassageCacheManager` uses to key cached responses, so caching behavior is unchanged.
- `config/passage.php`: new `security.add_forwarded_headers` option (default `true`, env `PASSAGE_ADD_FORWARDED_HEADERS`) so deployments that shouldn't reveal client IPs upstream can disable it.
- `README.md`: documents the new headers and the config switch.
- Tests added to `ForwardedHeaderResolverTest` and `PassageServiceTest` covering the new header values, chain-appending, and the disable switch.

Fixes #89

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` (full suite, 217 tests) — all passing
