### PR TITLE
chore(release): v3.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "morcen/passage",
-    "version": "v3.1.1",
+    "version": "v3.1.2",
     "description": "API gateway for Laravel",
     "keywords": [
         "morcen",


### PR DESCRIPTION
## Summary

Bumps the package version from `v3.1.1` to `v3.1.2` (PATCH release).

Since `v3.1.1` was released, 14 commits landed on `main`, all bug fixes and test coverage with no new features or breaking changes:

- fix: add X-Forwarded-* headers to upstream requests (#218)
- fix: require stable composer dependencies instead of dev stability (#217)
- fix: declare transitive composer dependencies used directly by src/ (#216)
- fix: make PassageEventSubscriber fall back to the default log channel (#215)
- fix(commands): return failure exit code when passage:controller generation fails (#214)
- fix: passage:list returns success exit code when Passage is disabled (#213)
- fix: match passage:list routes by fully-qualified controller name (#212)
- fix: resolve passage:list handler targets through the container (#211)
- fix: share a single hop-by-hop header fallback list between request and response paths (#210)
- fix: validate handler name in passage:controller before use (#209)
- fix: stream uploaded files instead of buffering them into memory (#208)
- fix: passage:health now fails routes with a missing base_uri (#207)
- fix: match form-urlencoded Content-Type case-insensitively in PassageService (#206)
- test: cover passage:health probe() failure for unreachable hosts (#219)

## Changes

- Bump `"version"` in `composer.json` from `v3.1.1` to `v3.1.2`.
