### PR TITLE
fix: make hop-by-hop header stripping non-configurable, matching its docs

### DIFF
--- a/config/passage.php
+++ b/config/passage.php
@@ -95,15 +95,13 @@ return [
         'add_forwarded_headers' => env('PASSAGE_ADD_FORWARDED_HEADERS', true),
 
         /*
-        | Hop-by-hop headers are always stripped and cannot be configured.
-        | These are transport-level headers that must not be forwarded by
-        | any proxy (RFC 7230).
+        | Hop-by-hop headers (host, connection, transfer-encoding, upgrade,
+        | keep-alive, te, trailer, proxy-authenticate, proxy-authorization)
+        | are always stripped and are not configurable here. These are
+        | transport-level headers that must not be forwarded by any proxy
+        | (RFC 7230) — see Morcen\Passage\Support\ForwardedHeaderResolver::
+        | HOP_BY_HOP_HEADERS.
         */
-        'hop_by_hop_headers' => [
-            'host', 'connection', 'transfer-encoding', 'upgrade',
-            'keep-alive', 'te', 'trailer', 'proxy-authenticate',
-            'proxy-authorization',
-        ],
     ],
 
     /*

--- a/src/Http/PassageResponseBuilder.php
+++ b/src/Http/PassageResponseBuilder.php
@@ -72,7 +72,7 @@ class PassageResponseBuilder
 
     private function resolveResponseHeaders(Response $upstream): array
     {
-        $hopByHop = config('passage.security.hop_by_hop_headers', ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK);
+        $hopByHop = ForwardedHeaderResolver::HOP_BY_HOP_HEADERS;
         $headers = [];
 
         foreach ($upstream->headers() as $name => $values) {

--- a/src/Support/ForwardedHeaderResolver.php
+++ b/src/Support/ForwardedHeaderResolver.php
@@ -15,9 +15,9 @@ use Illuminate\Http\Request;
  */
 class ForwardedHeaderResolver
 {
-    // Fallback hop-by-hop list used when config is not available (e.g. early bootstrap).
+    // Hop-by-hop headers are always stripped and are not configurable (RFC 7230).
     // Public so PassageResponseBuilder can share it instead of maintaining its own copy.
-    public const HOP_BY_HOP_FALLBACK = [
+    public const HOP_BY_HOP_HEADERS = [
         'host', 'connection', 'transfer-encoding', 'upgrade',
         'keep-alive', 'te', 'trailer', 'proxy-authenticate',
         'proxy-authorization',
@@ -25,7 +25,7 @@ class ForwardedHeaderResolver
 
     public static function resolve(Request $request): array
     {
-        $hopByHop = config('passage.security.hop_by_hop_headers', self::HOP_BY_HOP_FALLBACK);
+        $hopByHop = self::HOP_BY_HOP_HEADERS;
         $headers = [];
 
         foreach ($request->headers->all() as $name => $values) {

--- a/tests/Unit/ForwardedHeaderResolverTest.php
+++ b/tests/Unit/ForwardedHeaderResolverTest.php
@@ -3,23 +3,18 @@
 use Illuminate\Http\Request;
 use Morcen\Passage\Support\ForwardedHeaderResolver;
 
-describe('ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK', function () {
-    it('matches the published config default for hop_by_hop_headers', function () {
-        expect(ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK)
-            ->toBe(config('passage.security.hop_by_hop_headers'));
+describe('ForwardedHeaderResolver::HOP_BY_HOP_HEADERS', function () {
+    it('includes proxy-authorization, since it is also a hop-by-hop header', function () {
+        expect(ForwardedHeaderResolver::HOP_BY_HOP_HEADERS)->toContain('proxy-authorization');
     });
 
-    it('includes proxy-authorization, since it is also a hop-by-hop header', function () {
-        expect(ForwardedHeaderResolver::HOP_BY_HOP_FALLBACK)->toContain('proxy-authorization');
+    it('is not sourced from config, since hop-by-hop stripping is not configurable', function () {
+        expect(config('passage.security.hop_by_hop_headers'))->toBeNull();
     });
 });
 
 describe('ForwardedHeaderResolver::resolve()', function () {
-    it('strips Proxy-Authorization from the forwarded request when config is unavailable', function () {
-        $security = config('passage.security');
-        unset($security['hop_by_hop_headers']);
-        config(['passage.security' => $security]);
-
+    it('strips Proxy-Authorization from the forwarded request', function () {
         $request = Request::create('/test', 'GET');
         $request->headers->set('Proxy-Authorization', 'Basic secret-credentials');
         $request->headers->set('X-Custom', 'keep-me');
@@ -28,6 +23,17 @@ describe('ForwardedHeaderResolver::resolve()', function () {
 
         expect($headers)->not->toHaveKey('Proxy-Authorization');
         expect($headers)->toHaveKey('X-Custom');
+    });
+
+    it('strips every hop-by-hop header even if config attempts to override the list', function () {
+        config(['passage.security.hop_by_hop_headers' => []]);
+
+        $request = Request::create('/test', 'GET');
+        $request->headers->set('Connection', 'keep-alive');
+
+        $headers = ForwardedHeaderResolver::resolve($request);
+
+        expect($headers)->not->toHaveKey('Connection');
     });
 });
 

--- a/tests/Unit/PassageResponseBuilderTest.php
+++ b/tests/Unit/PassageResponseBuilderTest.php
@@ -171,7 +171,7 @@ describe('PassageResponseBuilder::build()', function () {
             expect($response->headers->get('x-custom'))->toBe('pass-through');
         });
 
-        it('strips a Proxy-Authorization header on the upstream response using the published config default', function () {
+        it('strips a Proxy-Authorization header on the upstream response using the hard-coded hop-by-hop list', function () {
             $upstream = Mockery::mock(Response::class);
             $upstream->shouldReceive('status')->andReturn(200);
             $upstream->shouldReceive('body')->andReturn('{}');


### PR DESCRIPTION
## What was broken

`config/passage.php`'s `hop_by_hop_headers` entry carried this comment:

```
| Hop-by-hop headers are always stripped and cannot be configured.
```

But it was a plain, published config array. Both `ForwardedHeaderResolver::resolve()` (used to build the outbound request to upstream) and `PassageResponseBuilder::resolveResponseHeaders()` (used to build the response back to the client) read it via `config('passage.security.hop_by_hop_headers', ...)` with no guard whatsoever.

Since Passage is a security-sensitive HTTP proxy, this is a real gap: any application that runs `php artisan vendor:publish --tag=passage-config` and edits or removes an entry from this array (even accidentally, e.g. while customizing `strip_client_headers` nearby) silently weakens RFC 7230 hop-by-hop header stripping — for example letting `Proxy-Authorization` leak between hops — with the code offering no enforcement and the comment actively telling readers this isn't possible. Nothing in the test suite exercised overriding this config value either, so a regression here would have gone unnoticed.

## What changed

- Removed `hop_by_hop_headers` from `config/passage.php` entirely, so the documented "not configurable" behavior is now actually true, and expanded the comment to list the headers and point at the real source of truth.
- `ForwardedHeaderResolver` and `PassageResponseBuilder` no longer read this list from `config()`; they both use the shared `ForwardedHeaderResolver::HOP_BY_HOP_HEADERS` constant directly (renamed from `HOP_BY_HOP_FALLBACK`, since it's no longer a fallback for an absent config value — it's the sole source of truth).
- Updated/added tests: the list is asserted to include `proxy-authorization`, to not be sourced from config, and hop-by-hop stripping is asserted to be unaffected even if a `hop_by_hop_headers` config key is present at runtime (e.g. from a stale published config file).

## Testing

- `vendor/bin/pint --dirty` — passed, no changes needed.
- `composer test` (`vendor/bin/pest`) — full suite passes: 220 tests, 582 assertions.

Fixes #139