### PR TITLE
Add SECURITY.md so the linked security policy resolves

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+Passage is an API gateway for Laravel that handles authentication secrets
+(HMAC signatures, bearer tokens, API keys) and forwards HTTP traffic on your
+behalf, so security fixes are taken seriously. Only the latest major version
+receives security patches.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | :white_check_mark: |
+| 2.x     | :x:                |
+| 1.x     | :x:                |
+
+If you are on an unsupported version, please upgrade to the latest 3.x
+release before reporting an issue — it may already be fixed. See
+[UPGRADE.md](UPGRADE.md) for migration guidance.
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub
+issues.
+
+Instead, report them by:
+
+- Using GitHub's [private vulnerability reporting](https://github.com/morcen/passage/security/advisories/new) (preferred), or
+- Emailing **hello@morcen.com** with a description of the issue, steps to
+  reproduce, and any relevant logs or proof-of-concept code.
+
+You should expect an initial response within **5 business days**. We will
+keep you updated as the issue is investigated and fixed, and will credit you
+in the release notes unless you prefer to remain anonymous.
+
+## Scope
+
+Examples of issues in scope for this policy include (but aren't limited to):
+
+- Server-Side Request Forgery (SSRF) bypasses of the allowed-hosts guard or
+  redirect re-validation
+- HMAC/API key/bearer signature forging or verification bypasses
+- Header injection, request smuggling, or improper stripping of sensitive
+  headers
+- Any way to bypass Passage's proxying guards to reach an unintended upstream

--- a/tests/Unit/SecurityPolicyTest.php
+++ b/tests/Unit/SecurityPolicyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Regression test for #151: README.md and .github/ISSUE_TEMPLATE/config.yml
+ * both link to a GitHub-generated security policy page, which only resolves
+ * to real content once a SECURITY.md exists in the repository. Without it,
+ * both links silently 404 to GitHub's generic "no security policy" page.
+ */
+describe('security policy', function () {
+    it('has a SECURITY.md at the repository root', function () {
+        expect(file_exists(__DIR__.'/../../SECURITY.md'))->toBeTrue();
+    });
+
+    it('documents how to report a vulnerability and which versions are supported', function () {
+        $contents = file_get_contents(__DIR__.'/../../SECURITY.md');
+
+        expect($contents)
+            ->toContain('Supported Versions')
+            ->toContain('Reporting a Vulnerability');
+    });
+
+    it('is linked from the README security section', function () {
+        $readme = file_get_contents(__DIR__.'/../../README.md');
+
+        expect($readme)->toContain('../../security/policy');
+    });
+
+    it('is linked from the bug report issue template config', function () {
+        $config = file_get_contents(__DIR__.'/../../.github/ISSUE_TEMPLATE/config.yml');
+
+        expect($config)->toContain('https://github.com/morcen/passage/security/policy');
+    });
+});


### PR DESCRIPTION
## What was broken

`README.md` and `.github/ISSUE_TEMPLATE/config.yml` both point readers at `https://github.com/morcen/passage/security/policy` for reporting security vulnerabilities, but no `SECURITY.md` existed in the repository. Both links only ever resolved to GitHub's generic "no security policy configured" page instead of real reporting instructions.

For a package that proxies/forwards HTTP requests and handles auth secrets (HMAC, bearer tokens, API keys), a broken security-disclosure path is a real gap: a researcher who finds a genuine vulnerability has no clear private channel to report it and may default to filing a public issue instead.

## What changed

- Added `SECURITY.md` at the repo root with:
  - A supported-versions table (only the latest 3.x line receives fixes)
  - Reporting instructions (GitHub private vulnerability reporting or email)
  - An expected initial response time
  - Examples of in-scope issues (SSRF bypasses, signature forging, header injection, etc.)
- Added `tests/Unit/SecurityPolicyTest.php` asserting `SECURITY.md` exists, documents the key sections, and that the README/issue-template links still point at the right place — so this can't silently regress.

GitHub automatically surfaces `SECURITY.md` at the `security/policy` URL once it exists, so no changes were needed to the existing links in `README.md` or `config.yml`.

Fixes #151

## Testing

- `vendor/bin/pint --dirty` — no changes needed
- `composer test` — 224 passed (587 assertions), including the 4 new tests