### PR TITLE
Widen HasResilienceOptions::withRetry() to accept Laravel's native array/Closure retry parameters

### DIFF
--- a/src/Concerns/HasResilienceOptions.php
+++ b/src/Concerns/HasResilienceOptions.php
@@ -2,6 +2,7 @@
 
 namespace Morcen\Passage\Concerns;
 
+use Closure;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Throwable;
@@ -12,10 +13,19 @@ trait HasResilienceOptions
      * Return retry configuration to merge into getOptions().
      *
      * Passage will extract these keys before passing options to Guzzle and
-     * apply ->retry() on the PendingRequest automatically.
+     * apply ->retry() on the PendingRequest automatically. Both parameters
+     * are passed straight through to Laravel's PendingRequest::retry(), so
+     * they accept the same shapes it does: an array of $times lets you
+     * define a fixed number of attempts per backoff step, and a Closure for
+     * $sleepMs lets you compute the delay per attempt (e.g. exponential
+     * backoff with jitter).
      *
-     * @param  int  $times  Maximum number of retry attempts.
-     * @param  int  $sleepMs  Milliseconds to wait between retries.
+     * @param  int|array<int, int>  $times  Maximum number of retry attempts, or an array of
+     *                                      per-attempt delays in milliseconds (its length
+     *                                      determines the number of attempts).
+     * @param  int|Closure  $sleepMs  Milliseconds to wait between retries, or a
+     *                                Closure(int $attempt, Throwable $exception): int
+     *                                that computes the delay per attempt.
      * @param  callable|null  $when  Optional callable(Throwable $exception, PendingRequest $request): bool.
      *                               When null, retries on connection errors and 5xx responses only —
      *                               NOT on 4xx client errors, since Laravel's own retry default would
@@ -31,8 +41,17 @@ trait HasResilienceOptions
      *           $this->withRetry(3, 200)
      *       );
      *   }
+     *
+     * Example with exponential backoff and jitter:
+     *   public function getOptions(): array
+     *   {
+     *       return array_merge(
+     *           ['base_uri' => 'https://api.example.com/'],
+     *           $this->withRetry(3, fn (int $attempt) => (2 ** $attempt) * 100 + random_int(0, 100))
+     *       );
+     *   }
      */
-    protected function withRetry(int $times, int $sleepMs = 100, ?callable $when = null): array
+    protected function withRetry(int|array $times, int|Closure $sleepMs = 100, ?callable $when = null): array
     {
         return array_filter([
             'passage_retry_times' => $times,

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -42,6 +42,17 @@ class RetryableHandler extends PassageHandler
     }
 }
 
+class BackoffRetryableHandler extends PassageHandler
+{
+    public function getOptions(): array
+    {
+        return array_merge(
+            ['base_uri' => 'https://api.example.com/'],
+            $this->withRetry([100, 200, 400], fn (int $attempt) => $attempt * 100)
+        );
+    }
+}
+
 class CachedHandler extends PassageHandler
 {
     public function getOptions(): array
@@ -187,6 +198,64 @@ describe('3.1 Retry ergonomics', function () {
             'passage_retry_times' => 3,
             'passage_retry_sleep_ms' => 200,
         ]);
+    });
+
+    it('withRetry() accepts an array of per-attempt delays for $times', function () {
+        $handler = new class
+        {
+            use HasResilienceOptions;
+
+            public function options(): array
+            {
+                return $this->withRetry([100, 200, 400], 200);
+            }
+        };
+
+        expect($handler->options())->toMatchArray([
+            'passage_retry_times' => [100, 200, 400],
+            'passage_retry_sleep_ms' => 200,
+        ]);
+    });
+
+    it('withRetry() accepts a Closure for $sleepMs to compute exponential backoff with jitter', function () {
+        $backoff = fn (int $attempt) => (2 ** $attempt) * 100;
+
+        $handler = new class
+        {
+            use HasResilienceOptions;
+
+            public function options(Closure $sleepMs): array
+            {
+                return $this->withRetry(3, $sleepMs);
+            }
+        };
+
+        $opts = $handler->options($backoff);
+
+        expect($opts['passage_retry_sleep_ms'])->toBe($backoff);
+        expect($opts['passage_retry_times'])->toBe(3);
+    });
+
+    it('passes an array $times and Closure $sleepMs straight through to PendingRequest::retry()', function () {
+        $request = phase3Route(BackoffRetryableHandler::class);
+
+        Http::shouldReceive('withOptions')->once()->andReturn(
+            Mockery::mock(PendingRequest::class)
+                ->shouldReceive('retry')
+                ->withArgs(function ($actualTimes, $actualSleepMs) {
+                    return $actualTimes === [100, 200, 400]
+                        && $actualSleepMs instanceof Closure
+                        && $actualSleepMs(2) === 200;
+                })
+                ->once()
+                ->andReturnSelf()
+                ->getMock()
+        );
+
+        $this->mockService->shouldReceive('callService')
+            ->andReturn(jsonMockResponse(['ok' => true]));
+
+        phase3Controller()->handle($request);
     });
 
     it('passage_retry_* keys are stripped from guzzle options', function () {


### PR DESCRIPTION
## What was broken

`PassageController::handle()` calls Laravel's `PendingRequest::retry()` directly with whatever `withRetry()` produces. Laravel's `retry()` is typed `retry(array|int $times, Closure|int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)` and natively supports an array of per-attempt delays and a `Closure` for computing exponential-backoff-with-jitter delays per attempt.

`HasResilienceOptions::withRetry()` — the documented ergonomic entry point (README: "Automatic retry with configurable backoff") — strictly typed both parameters as `int`:

```php
protected function withRetry(int $times, int $sleepMs = 100, ?callable $when = null): array
```

so it could only ever produce a single fixed delay. A caller could not get exponential backoff or jitter through the documented helper at all — only by bypassing it and hand-building the undocumented `passage_retry_*` array keys directly, despite the underlying plumbing supporting it end-to-end.

## What changed

- Widened `withRetry()`'s parameter types to `int|array $times` and `int|Closure $sleepMs`, matching Laravel's own `retry()` signature. These values are merged into `getOptions()` unchanged and passed straight through to `PendingRequest::retry()`, so no other code needed to change.
- Updated the docblock with an exponential-backoff-with-jitter example.
- Added Pest coverage in `tests/Unit/Phase3Test.php` for:
  - `withRetry()` accepting an array of per-attempt delays for `$times`.
  - `withRetry()` accepting a `Closure` for `$sleepMs`.
  - The array/Closure values passing straight through to `PendingRequest::retry()` via the controller.

## Testing

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/pest` — 227 passed (595 assertions)

Fixes #179