### PR TITLE
fix: remove unused $ttl parameter from PassageCacheManager::get()

### DIFF
--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -166,7 +166,7 @@ class PassageController extends Controller
         $forwardedHeaders = ForwardedHeaderResolver::resolve($request);
 
         if ($cacheTtl !== null) {
-            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheTtl, $cacheableOptions, $request->query(), $forwardedHeaders);
+            $cached = $this->cacheManager->get($request->method(), $fullUrl, $cacheableOptions, $request->query(), $forwardedHeaders);
             if ($cached !== null) {
                 $upstream = $handlerInstance->getResponse($request, $cached);
                 $this->fireEvent(new PassageResponseReceived($request, $upstream, $handler, 0.0, true));

--- a/src/Http/PassageCacheManager.php
+++ b/src/Http/PassageCacheManager.php
@@ -13,7 +13,6 @@ class PassageCacheManager
      * Returns null on a cache miss, or if caching is not applicable.
      * (only GET and HEAD responses are cached).
      *
-     * @param  int  $ttl  Cache time-to-live in seconds.
      * @param  array  $options  Request options used to generate the cache key.
      * @param  array  $query  Request query parameters used to generate the cache key.
      * @param  array  $headers  Forwarded request headers used to generate the cache key, so
@@ -21,7 +20,7 @@ class PassageCacheManager
      *                          a cached response.
      * @return Response|null Cached response, or null on a miss.
      */
-    public function get(string $method, string $fullUrl, int $ttl, array $options, array $query = [], array $headers = []): ?Response
+    public function get(string $method, string $fullUrl, array $options, array $query = [], array $headers = []): ?Response
     {
         if (! $this->isCacheable($method)) {
             return null;

--- a/tests/Unit/PassageCacheManagerTest.php
+++ b/tests/Unit/PassageCacheManagerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Cache;
+use Morcen\Passage\Http\PassageCacheManager;
+
+beforeEach(function () {
+    config(['passage.cache.store' => 'array']);
+});
+
+function cacheManagerResponse(array $data = [], int $status = 200): Response
+{
+    return new Response(new Psr7Response($status, ['Content-Type' => 'application/json'], json_encode($data)));
+}
+
+it('returns null on a cache miss', function () {
+    $manager = new PassageCacheManager;
+
+    expect($manager->get('GET', 'https://api.example.com/users', []))->toBeNull();
+});
+
+it('never caches a non-GET/HEAD method', function () {
+    $manager = new PassageCacheManager;
+
+    // A POST request is never cacheable, regardless of what's in the store.
+    $manager->put('POST', 'https://api.example.com/users', 60, [], cacheManagerResponse(['id' => 1]));
+
+    expect($manager->get('POST', 'https://api.example.com/users', []))->toBeNull();
+});
+
+it('stores and retrieves a GET response round-trip', function () {
+    $manager = new PassageCacheManager;
+
+    $manager->put('GET', 'https://api.example.com/users', 60, [], cacheManagerResponse(['id' => 1]), [], []);
+
+    $cached = $manager->get('GET', 'https://api.example.com/users', [], [], []);
+
+    expect($cached)->not->toBeNull()
+        ->and($cached->status())->toBe(200)
+        ->and($cached->json())->toBe(['id' => 1]);
+});
+
+it('does not cache a non-2xx upstream response', function () {
+    $manager = new PassageCacheManager;
+
+    $manager->put('GET', 'https://api.example.com/users', 60, [], cacheManagerResponse(['error' => 'boom'], 500));
+
+    expect($manager->get('GET', 'https://api.example.com/users', []))->toBeNull();
+});
+
+it('produces a cache key that is stable regardless of query parameter order', function () {
+    $manager = new PassageCacheManager;
+
+    $manager->put(
+        'GET',
+        'https://api.example.com/users',
+        60,
+        [],
+        cacheManagerResponse(['id' => 1]),
+        ['a' => '1', 'b' => '2']
+    );
+
+    $cached = $manager->get('GET', 'https://api.example.com/users', [], ['b' => '2', 'a' => '1']);
+
+    expect($cached)->not->toBeNull()
+        ->and($cached->json())->toBe(['id' => 1]);
+});
+
+it('produces a cache key that is stable regardless of header order', function () {
+    $manager = new PassageCacheManager;
+
+    $manager->put(
+        'GET',
+        'https://api.example.com/users',
+        60,
+        [],
+        cacheManagerResponse(['id' => 1]),
+        [],
+        ['Authorization' => 'Bearer token', 'Accept' => 'application/json']
+    );
+
+    $cached = $manager->get(
+        'GET',
+        'https://api.example.com/users',
+        [],
+        [],
+        ['Accept' => 'application/json', 'Authorization' => 'Bearer token']
+    );
+
+    expect($cached)->not->toBeNull()
+        ->and($cached->json())->toBe(['id' => 1]);
+});
+
+it('does not share a cached response between requests with different headers', function () {
+    $manager = new PassageCacheManager;
+
+    $manager->put('GET', 'https://api.example.com/users', 60, [], cacheManagerResponse(['id' => 1]), [], ['Authorization' => 'Bearer one']);
+
+    $cached = $manager->get('GET', 'https://api.example.com/users', [], [], ['Authorization' => 'Bearer two']);
+
+    expect($cached)->toBeNull();
+});
+
+it('resolves the cache store from the passage.cache.store config value', function () {
+    config(['passage.cache.store' => 'redis']);
+
+    $store = Mockery::mock(Repository::class);
+    $store->shouldReceive('get')->once()->andReturn(null);
+
+    Cache::shouldReceive('store')->once()->with('redis')->andReturn($store);
+
+    $manager = new PassageCacheManager;
+
+    expect($manager->get('GET', 'https://api.example.com/users', []))->toBeNull();
+});


### PR DESCRIPTION
## What was broken

`PassageCacheManager::get()` declared a `$ttl` parameter that was never referenced anywhere in the method body. Cache expiry is enforced entirely by the underlying cache store via the TTL passed to `put()`, so `get()`'s `$ttl` argument was dead API surface. This was misleading: a reader could reasonably assume `get()` used `$ttl` for some freshness check (e.g. re-validating a stale-but-present entry), when in fact it was silently ignored.

`PassageCacheManager` also had no dedicated unit test — it was only exercised indirectly through `PassageControllerTest.php` and `Phase3Test.php` — so `key()`'s canonicalization behavior, `store()` config resolution, and `get()`/`put()` round-tripping had no direct coverage.

## What changed

- Removed the unused `$ttl` parameter from `PassageCacheManager::get()`'s signature.
- Updated `PassageController`'s single call site accordingly.
- Added `tests/Unit/PassageCacheManagerTest.php` covering:
  - `get()`/`put()` round-tripping for a cacheable GET response
  - non-cacheable HTTP methods are never cached
  - non-2xx responses are never cached
  - cache-key stability when query parameters or headers are reordered
  - cache-key isolation between requests with different headers
  - `store()` correctly resolves the configured cache store

Fixes #154

## Testing

- `vendor/bin/pint --dirty` passes
- `composer test` — full suite passes (235 tests, 609 assertions)