### PR TITLE
docs: correct PassageEventSubscriber log level claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ protected $subscribe = [
 ];
 ```
 
-This subscriber logs to a `passage` channel at `info` level (request/response) and `error` level (failures).
+This subscriber logs to a `passage` channel at `debug` level for outgoing requests, `info` level for responses, and `error` level for failures.
 
 To disable events:
 

--- a/tests/Unit/ReadmeEventSubscriberLogLevelsTest.php
+++ b/tests/Unit/ReadmeEventSubscriberLogLevelsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Regression test for #180: README.md claimed PassageEventSubscriber logs
+ * both outgoing requests and responses at "info" level, but
+ * onRequestSending() actually logs at "debug" (see
+ * PassageEventSubscriberTest, which asserts Log::shouldReceive('debug') for
+ * that event). Someone configuring their "passage" log channel at "info"
+ * based on the README would silently lose all request-sending log entries.
+ *
+ * This guards against the README drifting from the documented log levels
+ * again.
+ */
+describe('README PassageEventSubscriber docs', function () {
+    it('documents the actual debug/info/error log levels used by PassageEventSubscriber', function () {
+        $readme = file_get_contents(__DIR__.'/../../README.md');
+
+        expect($readme)->toContain(
+            'This subscriber logs to a `passage` channel at `debug` level for outgoing requests, `info` level for responses, and `error` level for failures.'
+        );
+    });
+});


### PR DESCRIPTION
## What was broken

The README stated:

> This subscriber logs to a `passage` channel at `info` level (request/response) and `error` level (failures).

This implied both `PassageRequestSending` and `PassageResponseReceived` log at `info` level. In reality, `PassageEventSubscriber::onRequestSending()` logs at `debug` level — only `onResponseReceived()` logs at `info`. `tests/Unit/PassageEventSubscriberTest.php` already asserts `Log::shouldReceive('debug')` for the sending event, confirming the code (not the README) reflects the actual, intended behavior.

Anyone configuring their `passage` log channel at `info` level based on the README would silently lose all "Passage: forwarding request" log entries in production.

## What changed

- Updated `README.md` to accurately describe the log levels: `debug` for outgoing requests, `info` for responses, `error` for failures.
- Added `tests/Unit/ReadmeEventSubscriberLogLevelsTest.php`, a regression test (following the existing `ComposerVersionFieldTest`/`ComposerStabilityTest` pattern in this repo) asserting the README text matches the documented log levels, to catch this drifting again.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (237 passed, 611 assertions)

Fixes #180