### PR TITLE
fix: remove stale spatie skeleton artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,13 +6,5 @@
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore
-/art                export-ignore
-/docs               export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
-/.php_cs.dist.php   export-ignore
-/psalm.xml          export-ignore
-/psalm.xml.dist     export-ignore
-/testbench.yaml     export-ignore
-/UPGRADING.md       export-ignore
-

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Morcen\\Passage\\": "src",
-            "Morcen\\Passage\\Database\\Factories\\": "database/factories"
+            "Morcen\\Passage\\": "src"
         }
     },
     "autoload-dev": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,21 +2,11 @@
 
 namespace Morcen\Passage\Tests;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Morcen\Passage\PassageServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'Morcen\\Passage\\Database\\Factories\\'.class_basename($modelName).'Factory'
-        );
-    }
-
     protected function getPackageProviders($app)
     {
         return [
@@ -27,10 +17,5 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
-
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_passage_table.php.stub';
-        $migration->up();
-        */
     }
 }

--- a/tests/Unit/StaleSkeletonArtifactsTest.php
+++ b/tests/Unit/StaleSkeletonArtifactsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Regression test for #143: Passage started from the standard
+ * spatie/laravel-package-tools skeleton, and a few skeleton leftovers were
+ * never cleaned up once the package settled into its current (model-less)
+ * shape:
+ *
+ * - composer.json declared a PSR-4 autoload mapping to a "database/factories"
+ *   directory that doesn't exist anywhere in the repo (Passage has no
+ *   Eloquent models, so there's nothing to have factories for).
+ * - .gitattributes listed several "export-ignore" paths from the skeleton
+ *   that don't exist in this repo, and referenced "/UPGRADING.md" under the
+ *   skeleton's old name instead of the repo's actual "UPGRADE.md".
+ */
+describe('composer.json autoload', function () {
+    it('does not declare a PSR-4 mapping for a nonexistent database/factories directory', function () {
+        $composer = json_decode(file_get_contents(__DIR__.'/../../composer.json'), true);
+
+        expect($composer['autoload']['psr-4'])->not->toHaveKey('Morcen\\Passage\\Database\\Factories\\');
+    });
+});
+
+describe('.gitattributes', function () {
+    it('does not export-ignore paths that do not exist in the repository', function () {
+        $gitattributes = file_get_contents(__DIR__.'/../../.gitattributes');
+
+        preg_match_all('/^\/(\S+)\s+export-ignore$/m', $gitattributes, $matches);
+
+        foreach ($matches[1] as $path) {
+            expect(file_exists(__DIR__.'/../../'.$path))
+                ->toBeTrue("Expected export-ignored path \"{$path}\" to exist in the repository.");
+        }
+    });
+
+    it("does not reference the skeleton's old UPGRADING.md filename", function () {
+        $gitattributes = file_get_contents(__DIR__.'/../../.gitattributes');
+
+        expect($gitattributes)->not->toContain('UPGRADING.md');
+    });
+});


### PR DESCRIPTION
## What was broken

Passage started from the standard `spatie/laravel-package-tools` skeleton, and a few skeleton leftovers were never cleaned up once the package settled into its current (model-less) shape:

1. `composer.json` declared a PSR-4 autoload mapping to `database/factories`, a directory that doesn't exist anywhere in the repo. Passage has no Eloquent models, so there's nothing to have factories for — every `composer dump-autoload` silently resolved this no-op rule.
2. `tests/TestCase.php` wired `Factory::guessFactoryNamesUsing()` to that same nonexistent `Morcen\Passage\Database\Factories\` namespace, and had a commented-out migration `include` referencing a stub (`database/migrations/create_passage_table.php.stub`) that has never existed in this repo.
3. `.gitattributes` listed several `export-ignore` paths from the skeleton that don't exist in this repo (`art`, `docs`, `.php_cs.dist.php`, `psalm.xml`, `psalm.xml.dist`, `testbench.yaml`), and referenced `/UPGRADING.md` under the skeleton's old filename — the file that actually exists at the repo root is `UPGRADE.md`, so it wasn't covered by the `export-ignore` rule at all.

Individually harmless, but together this is confusing/misleading cruft for anyone reading the package metadata to understand its structure.

## What changed

- Removed the dead `Morcen\Passage\Database\Factories\` PSR-4 entry from `composer.json`.
- Removed the now-unused `Factory::guessFactoryNamesUsing()` wiring and the dead commented-out migration block from `tests/TestCase.php`.
- Pruned `.gitattributes` down to paths that actually exist in the repo, and dropped the stale `/UPGRADING.md` entry (consistent with how `README.md`/`CHANGELOG.md`/`UPGRADE.md` are already shipped, not export-ignored).
- Added `tests/Unit/StaleSkeletonArtifactsTest.php`, a regression test (following the existing `ComposerVersionFieldTest`/`ComposerDependenciesTest` pattern) asserting `composer.json` doesn't declare the dead autoload mapping, and that every `export-ignore` path in `.gitattributes` exists in the repo.

## Testing

- `vendor/bin/pint --dirty` — passed
- `composer test` — full suite passes (239 passed, 618 assertions)

Fixes #143