### PR TITLE
Extract PassageRouteRegistry to deduplicate handler discovery

### DIFF
--- a/src/Commands/PassageHealthCommand.php
+++ b/src/Commands/PassageHealthCommand.php
@@ -3,10 +3,8 @@
 namespace Morcen\Passage\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
-use Morcen\Passage\Http\Controllers\PassageController;
-use Morcen\Passage\PassageControllerInterface;
+use Morcen\Passage\Support\PassageRouteRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
@@ -18,6 +16,11 @@ class PassageHealthCommand extends Command
 
     public $description = 'Ping the base_uri of every registered Passage route and report connectivity.';
 
+    public function __construct(protected readonly PassageRouteRegistry $routeRegistry)
+    {
+        parent::__construct();
+    }
+
     public function handle(): int
     {
         if (! config('passage.enabled', true)) {
@@ -26,7 +29,7 @@ class PassageHealthCommand extends Command
             return self::SUCCESS;
         }
 
-        $routes = $this->passageRoutes();
+        $routes = $this->routeRegistry->routes();
 
         if ($routes->isEmpty()) {
             $this->warn('No Passage routes are registered.');
@@ -39,13 +42,13 @@ class PassageHealthCommand extends Command
         $anyFailed = false;
 
         foreach ($routes as $route) {
-            $handler = $route->defaults['_passage_handler'] ?? null;
+            $handler = $this->routeRegistry->handlerClassFor($route);
 
             if (! $handler) {
                 continue;
             }
 
-            if (! class_exists($handler) || ! is_subclass_of($handler, PassageControllerInterface::class)) {
+            if (! $this->routeRegistry->isValidHandler($handler)) {
                 $rows[] = [class_basename($handler), '—', '<fg=red>FAIL</>', 'Invalid or missing handler class'];
                 $anyFailed = true;
 
@@ -53,8 +56,8 @@ class PassageHealthCommand extends Command
             }
 
             try {
-                $handlerInstance = app($handler);
-                $options = array_merge(config('passage.options', []), $handlerInstance->getOptions());
+                $handlerInstance = $this->routeRegistry->resolveHandler($handler);
+                $options = $this->routeRegistry->optionsFor($handlerInstance);
             } catch (Throwable $e) {
                 $rows[] = [class_basename($handler), '—', '<fg=red>FAIL</>', 'Could not resolve handler: '.$e->getMessage()];
                 $anyFailed = true;
@@ -119,14 +122,5 @@ class PassageHealthCommand extends Command
         } catch (Throwable $e) {
             return [false, 0, $e->getMessage()];
         }
-    }
-
-    private function passageRoutes(): Collection
-    {
-        return collect(app('router')->getRoutes())
-            ->filter(fn ($route) => str_contains(
-                $route->getActionName(),
-                PassageController::class.'@handle'
-            ));
     }
 }

--- a/src/Commands/PassageListCommand.php
+++ b/src/Commands/PassageListCommand.php
@@ -3,9 +3,7 @@
 namespace Morcen\Passage\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Route;
-use Morcen\Passage\Http\Controllers\PassageController;
-use Morcen\Passage\PassageControllerInterface;
+use Morcen\Passage\Support\PassageRouteRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
@@ -15,6 +13,11 @@ class PassageListCommand extends Command
     public $signature = 'passage:list';
 
     public $description = 'List all registered Passage proxy routes.';
+
+    public function __construct(protected readonly PassageRouteRegistry $routeRegistry)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
@@ -26,13 +29,8 @@ class PassageListCommand extends Command
 
         $rows = [];
 
-        foreach (Route::getRoutes() as $route) {
-            $uses = $route->getAction('uses');
-            if (! is_string($uses) || ! str_contains($uses, PassageController::class.'@handle')) {
-                continue;
-            }
-
-            $handler = $route->defaults['_passage_handler'] ?? null;
+        foreach ($this->routeRegistry->routes() as $route) {
+            $handler = $this->routeRegistry->handlerClassFor($route);
             $rows[] = [
                 implode('|', $route->methods()),
                 $route->uri(),
@@ -53,13 +51,13 @@ class PassageListCommand extends Command
 
     private function resolveTarget(string $handler): string
     {
-        if (! class_exists($handler) || ! is_subclass_of($handler, PassageControllerInterface::class)) {
+        if (! $this->routeRegistry->isValidHandler($handler)) {
             return $handler;
         }
 
         try {
-            $instance = app($handler);
-            $options = $instance->getOptions();
+            $instance = $this->routeRegistry->resolveHandler($handler);
+            $options = $this->routeRegistry->optionsFor($instance);
         } catch (Throwable) {
             return $handler.' (could not resolve target)';
         }

--- a/src/Http/Controllers/PassageController.php
+++ b/src/Http/Controllers/PassageController.php
@@ -2,7 +2,6 @@
 
 namespace Morcen\Passage\Http\Controllers;
 
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
@@ -19,9 +18,9 @@ use Morcen\Passage\Guards\AllowedHostsGuard;
 use Morcen\Passage\Http\PassageCacheManager;
 use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
-use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
 use Morcen\Passage\Support\ForwardedHeaderResolver;
+use Morcen\Passage\Support\PassageRouteRegistry;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
@@ -42,7 +41,7 @@ class PassageController extends Controller
         protected readonly AllowedHostsGuard $allowedHostsGuard,
         protected readonly PassageCacheManager $cacheManager,
         protected readonly PassageErrorHandler $errorHandler,
-        protected readonly Application $app,
+        protected readonly PassageRouteRegistry $routeRegistry,
     ) {}
 
     public function handle(Request $request): Response
@@ -51,13 +50,10 @@ class PassageController extends Controller
             return response()->json(['error' => 'Route not found'], Response::HTTP_NOT_FOUND);
         }
 
-        $handler = $request->route()->defaults['_passage_handler'] ?? null;
+        $handler = $this->routeRegistry->handlerClassFor($request->route());
         $path = (string) $request->route('path', '');
 
-        if (! $handler
-            || ! class_exists($handler)
-            || ! is_subclass_of($handler, PassageControllerInterface::class)
-        ) {
+        if (! $this->routeRegistry->isValidHandler($handler)) {
             return response()->json(['error' => 'Route not found'], Response::HTTP_NOT_FOUND);
         }
 
@@ -65,8 +61,8 @@ class PassageController extends Controller
             return response()->json(['error' => 'Invalid path'], Response::HTTP_BAD_REQUEST);
         }
 
-        $handlerInstance = $this->app->make($handler);
-        $mergedOptions = array_merge(config('passage.options', []), $handlerInstance->getOptions());
+        $handlerInstance = $this->routeRegistry->resolveHandler($handler);
+        $mergedOptions = $this->routeRegistry->optionsFor($handlerInstance);
 
         try {
             if (empty($mergedOptions['base_uri'])) {

--- a/src/Support/PassageRouteRegistry.php
+++ b/src/Support/PassageRouteRegistry.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Morcen\Passage\Support;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Morcen\Passage\Http\Controllers\PassageController;
+use Morcen\Passage\PassageControllerInterface;
+
+/**
+ * Single source of truth for discovering Passage routes and resolving their
+ * handlers, shared by PassageController, PassageHealthCommand, and
+ * PassageListCommand. Keeping this logic in one place prevents those three
+ * call sites from drifting apart on how a handler is matched, validated, or
+ * resolved (as previously happened between #211 and #212).
+ */
+class PassageRouteRegistry
+{
+    public function __construct(protected readonly Application $app) {}
+
+    /**
+     * All routes registered through Passage::get()/post()/etc., i.e. every
+     * route dispatched to PassageController::handle().
+     *
+     * @return Collection<int, Route>
+     */
+    public function routes(): Collection
+    {
+        return collect(RouteFacade::getRoutes())
+            ->filter(fn (Route $route) => str_contains(
+                (string) $route->getActionName(),
+                PassageController::class.'@handle'
+            ));
+    }
+
+    /**
+     * The Passage handler class configured on a route, if any.
+     */
+    public function handlerClassFor(Route $route): ?string
+    {
+        return $route->defaults['_passage_handler'] ?? null;
+    }
+
+    /**
+     * Whether $handler names a class that can actually be resolved as a
+     * Passage handler.
+     */
+    public function isValidHandler(?string $handler): bool
+    {
+        return $handler !== null
+            && class_exists($handler)
+            && is_subclass_of($handler, PassageControllerInterface::class);
+    }
+
+    /**
+     * Resolve a handler class through the container, so constructor
+     * dependencies are honoured the same way everywhere.
+     */
+    public function resolveHandler(string $handler): PassageControllerInterface
+    {
+        return $this->app->make($handler);
+    }
+
+    /**
+     * Merge the package-wide default options with the handler's own,
+     * letting the handler override any default.
+     *
+     * @return array<string, mixed>
+     */
+    public function optionsFor(PassageControllerInterface $handler): array
+    {
+        return array_merge(config('passage.options', []), $handler->getOptions());
+    }
+}

--- a/tests/Unit/PassageControllerTest.php
+++ b/tests/Unit/PassageControllerTest.php
@@ -17,6 +17,7 @@ use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageControllerInterface;
 use Morcen\Passage\Services\PassageServiceInterface;
+use Morcen\Passage\Support\PassageRouteRegistry;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -170,7 +171,7 @@ beforeEach(function () {
         new AllowedHostsGuard,
         new PassageCacheManager,
         new PassageErrorHandler,
-        app(),
+        new PassageRouteRegistry(app()),
     );
 });
 

--- a/tests/Unit/PassageRouteRegistryTest.php
+++ b/tests/Unit/PassageRouteRegistryTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Morcen\Passage\Facades\Passage;
+use Morcen\Passage\PassageControllerInterface;
+use Morcen\Passage\Support\PassageRouteRegistry;
+
+class RegistryTestPassageController implements PassageControllerInterface
+{
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => 'https://api.example.com'];
+    }
+}
+
+class RegistryTestDependency
+{
+    public function baseUri(): string
+    {
+        return 'https://dependency.example.com';
+    }
+}
+
+class DependentRegistryTestPassageController implements PassageControllerInterface
+{
+    public function __construct(private RegistryTestDependency $dependency) {}
+
+    public function getRequest(Request $request): Request
+    {
+        return $request;
+    }
+
+    public function getResponse(Request $request, Response $response): Response
+    {
+        return $response;
+    }
+
+    public function getOptions(): array
+    {
+        return ['base_uri' => $this->dependency->baseUri()];
+    }
+}
+
+describe('PassageRouteRegistry::routes()', function () {
+    it('returns only routes registered through the Passage facade', function () {
+        Passage::get('github/{path?}', RegistryTestPassageController::class);
+        Route::get('unrelated/{path?}', fn () => 'not a Passage route');
+
+        $routes = app(PassageRouteRegistry::class)->routes();
+
+        expect($routes)->toHaveCount(1);
+        expect($routes->first()->uri())->toBe('github/{path?}');
+    });
+
+    it('returns an empty collection when no Passage routes are registered', function () {
+        expect(app(PassageRouteRegistry::class)->routes())->toBeEmpty();
+    });
+});
+
+describe('PassageRouteRegistry::handlerClassFor()', function () {
+    it('reads the _passage_handler route default', function () {
+        $route = Passage::get('github/{path?}', RegistryTestPassageController::class);
+
+        expect(app(PassageRouteRegistry::class)->handlerClassFor($route))
+            ->toBe(RegistryTestPassageController::class);
+    });
+
+    it('returns null when the route has no _passage_handler default', function () {
+        $route = Route::get('unrelated/{path?}', fn () => 'not a Passage route');
+
+        expect(app(PassageRouteRegistry::class)->handlerClassFor($route))->toBeNull();
+    });
+});
+
+describe('PassageRouteRegistry::isValidHandler()', function () {
+    it('is true for a class implementing PassageControllerInterface', function () {
+        expect(app(PassageRouteRegistry::class)->isValidHandler(RegistryTestPassageController::class))
+            ->toBeTrue();
+    });
+
+    it('is false for null', function () {
+        expect(app(PassageRouteRegistry::class)->isValidHandler(null))->toBeFalse();
+    });
+
+    it('is false for a class that does not exist', function () {
+        expect(app(PassageRouteRegistry::class)->isValidHandler('App\\Handlers\\DeletedPassageController'))
+            ->toBeFalse();
+    });
+
+    it('is false for a class that does not implement PassageControllerInterface', function () {
+        expect(app(PassageRouteRegistry::class)->isValidHandler(RegistryTestDependency::class))
+            ->toBeFalse();
+    });
+});
+
+describe('PassageRouteRegistry::resolveHandler()', function () {
+    it('resolves a handler with constructor dependencies through the container', function () {
+        $handler = app(PassageRouteRegistry::class)->resolveHandler(DependentRegistryTestPassageController::class);
+
+        expect($handler)->toBeInstanceOf(DependentRegistryTestPassageController::class);
+        expect($handler->getOptions())->toBe(['base_uri' => 'https://dependency.example.com']);
+    });
+});
+
+describe('PassageRouteRegistry::optionsFor()', function () {
+    it('merges config(passage.options) with the handler own options', function () {
+        config()->set('passage.options', ['timeout' => 5, 'base_uri' => 'https://default.example.com']);
+
+        $handler = new RegistryTestPassageController;
+        $options = app(PassageRouteRegistry::class)->optionsFor($handler);
+
+        expect($options)->toBe([
+            'timeout' => 5,
+            // The handler's own base_uri wins over the configured default.
+            'base_uri' => 'https://api.example.com',
+        ]);
+    });
+});

--- a/tests/Unit/Phase3Test.php
+++ b/tests/Unit/Phase3Test.php
@@ -24,6 +24,7 @@ use Morcen\Passage\Http\PassageErrorHandler;
 use Morcen\Passage\Http\PassageResponseBuilder;
 use Morcen\Passage\PassageHandler;
 use Morcen\Passage\Services\PassageServiceInterface;
+use Morcen\Passage\Support\PassageRouteRegistry;
 use Symfony\Component\HttpFoundation\Response as ResponseCode;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -141,7 +142,7 @@ function phase3Controller(): PassageController
         new AllowedHostsGuard,
         new PassageCacheManager,
         new PassageErrorHandler,
-        app(),
+        new PassageRouteRegistry(app()),
     );
 }
 


### PR DESCRIPTION
## What was broken

`PassageController::handle()`, `PassageHealthCommand::passageRoutes()`, and `PassageListCommand::handle()` each independently implemented the same four steps: find Passage routes, read the `_passage_handler` route default, validate it against `PassageControllerInterface`, resolve it through the container, and merge `config('passage.options')` with the handler's `getOptions()`.

Because this logic was duplicated three times instead of shared, the implementations had already drifted apart twice in the past:
- `PassageListCommand` used to resolve handlers with `new $handler` instead of going through the container, which broke for handlers with constructor dependencies (later fixed to match the other two call sites).
- `PassageListCommand` used to match routes by a partial action-name substring instead of the fully-qualified controller class (later fixed to match `PassageHealthCommand`'s approach).

Nothing prevented a future change to any one of the three call sites from silently diverging from the other two again in the same way.

## What changed

- Added `Morcen\Passage\Support\PassageRouteRegistry`, the single place that:
  - finds all routes registered through the `Passage` facade (`routes()`)
  - reads a route's configured handler class (`handlerClassFor()`)
  - validates a handler class against `PassageControllerInterface` (`isValidHandler()`)
  - resolves a handler through the container (`resolveHandler()`)
  - merges `config('passage.options')` with the handler's own options (`optionsFor()`)
- Updated `PassageController::handle()`, `PassageHealthCommand`, and `PassageListCommand` to use the registry instead of their own copies of this logic.
- As part of unifying the three call sites, `PassageListCommand`'s target resolution now merges `config('passage.options')` with the handler's own options the same way the controller and health command already did, instead of using the handler's raw `getOptions()` alone.
- Removed the now-unused `Illuminate\Contracts\Foundation\Application $app` dependency from `PassageController`'s constructor, since handler resolution now goes through the registry.
- Added `tests/Unit/PassageRouteRegistryTest.php` covering the registry directly, and updated the existing controller tests that construct `PassageController` manually to pass the new `PassageRouteRegistry` dependency.

## Testing

- `vendor/bin/pint --dirty` — passed, no changes needed
- `vendor/bin/pest` — 250 passed (631 assertions), full suite green

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGa5tuhzv66zYWhZ6PWXXr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGa5tuhzv66zYWhZ6PWXXr)_