### PR TITLE
docs: add CONTRIBUTING.md referenced by the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Contributions are welcome and will be fully credited.
+
+We accept contributions via pull requests on [GitHub](https://github.com/morcen/passage).
+
+## Reporting bugs and requesting features
+
+Please use the [issue templates](https://github.com/morcen/passage/issues/new/choose) when opening a bug report or feature request — they help us get the details we need to help you.
+
+## Pull requests
+
+- **Branch from `main`.** Give your branch a short, descriptive name (e.g. `fix/redirect-guard-cache-key`).
+- **Follow existing conventions.** Match the style, naming, and structure already used in the codebase.
+- **Add tests.** New features and bug fixes should be covered by [Pest](https://pestphp.com) tests in the `tests/` directory.
+- **One pull request per feature.** If you want to contribute multiple unrelated changes, please submit them as separate pull requests.
+- **Keep commit messages clear.** Explain *what* changed and *why*.
+
+## Code style
+
+This project follows PSR-12, enforced by [Laravel Pint](https://laravel.com/docs/pint). Before committing, format the files you changed:
+
+```bash
+composer format
+```
+
+## Running tests
+
+The test suite is run with [Pest](https://pestphp.com):
+
+```bash
+composer test
+```
+
+Please make sure the full suite passes before opening a pull request.
+
+## Requirements
+
+- PHP 8.2 or higher
+- Laravel 11.x or 12.x
+
+**Happy coding**!


### PR DESCRIPTION
## What was broken

`README.md`'s "Contributing" section links to `CONTRIBUTING.md`:

```markdown
## Contributing

Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
```

but no `CONTRIBUTING.md` file existed anywhere in the repository (only `CHANGELOG.md`, `LICENSE.md`, `README.md`, and `UPGRADE.md` exist at the repo root), so the link 404'd on GitHub.

## What changed

Added `CONTRIBUTING.md` at the repo root, covering:

- Where to report bugs/feature requests (pointing at the existing issue templates)
- Branch/PR expectations (branch from `main`, add tests, one PR per feature)
- Code style, via the existing `composer format` (Pint) script
- Running the test suite, via the existing `composer test` (Pest) script
- Supported PHP/Laravel versions, matching the README's "Requirements" section

No application code was touched, so no test changes were needed; the full existing test suite (`composer test`) still passes (250 passed).

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab6eHRcjUdPBDFx2ZNZDhs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab6eHRcjUdPBDFx2ZNZDhs)_