### PR TITLE
docs: point README's upgrade section at UPGRADE.md instead of duplicating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,46 +571,7 @@ v3.0.0 is a **breaking release**. If you are on v2 and are not ready to migrate,
 "morcen/passage": "^2.0"
 ```
 
-### What changed
-
-| v2 | v3 |
-|----|----|
-| `config/passage.php` `services` array | Removed — routes are defined in route files |
-| `Route::passage()` in `routes/web.php` | Removed — use `Passage::get/post/...` instead |
-| Array-based handlers (`['base_uri' => '...']`) | Removed — a handler class is always required |
-
-### Migration steps
-
-**1. Remove `Route::passage()` from your route files.**
-
-**2. For each entry in `config/passage.php` `services`:**
-
-If the entry was an array:
-```php
-// v2 config/passage.php
-'github' => ['base_uri' => 'https://api.github.com/'],
-```
-
-Create a handler class (or use `passage:controller`) and move `base_uri` into `getOptions()`:
-```php
-// v3 app/Http/Controllers/Passages/GithubPassageController.php
-public function getOptions(): array
-{
-    return ['base_uri' => 'https://api.github.com/'];
-}
-```
-
-If the entry was already a controller class, it can be reused as-is — just make sure it implements `PassageControllerInterface`.
-
-**3. Register routes in your route files:**
-```php
-// v3 routes/web.php
-use Morcen\Passage\Facades\Passage;
-
-Passage::get('github/{path?}', GithubPassageController::class);
-```
-
-**4. Remove the `services` key from `config/passage.php`** (or re-publish the config with `php artisan vendor:publish --tag=passage-config --force`).
+For the full migration guide — what changed and the step-by-step migration — see [UPGRADE.md](UPGRADE.md#upgrading-from-v2x-to-v30).
 
 ---
 


### PR DESCRIPTION
## What was broken

`UPGRADE.md` and the README's `## Upgrading from v2` section (`README.md:566-615`) independently described the same v2→v3 breaking changes and migration steps, written with different wording and detail. Neither file referenced the other.

Because the two guides weren't derived from one source, a future breaking change was likely to get documented in only one of them, leaving the other stale and potentially contradictory — misleading for whichever guide a reader happened to land on.

## What changed

- Replaced the README's duplicated "What changed" table and step-by-step migration instructions with a short pointer to `UPGRADE.md#upgrading-from-v2x-to-v30`, which is now the single source of truth for the v2→v3 migration guide.
- Kept the `## Upgrading from v2` heading (and its anchor) intact, since it's still referenced by the "Upgrading from v2?" callout earlier in the README.
- `UPGRADE.md` itself is unchanged — it already covers this content in full and can grow to cover future major versions without bloating the README.

## Testing

- `vendor/bin/pint --dirty --test` — no PHP files changed, nothing to format.
- `vendor/bin/pest` — 250 passed (631 assertions), including the existing README/documentation link tests.

Fixes #161