### PR TITLE
docs: update stale example placeholders in the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -28,7 +28,7 @@ body:
       attributes:
           label: Package Version
           description: What version of our Package are you running? Please be as specific as possible
-          placeholder: 2.0.0
+          placeholder: 3.1.2
       validations:
           required: true
     - type: input
@@ -44,7 +44,7 @@ body:
       attributes:
         label: Laravel Version
         description: What version of Laravel are you running? Please be as specific as possible
-        placeholder: 9.0.0
+        placeholder: 12.0.0
       validations:
         required: true
     - type: dropdown

--- a/tests/Unit/BugReportTemplateTest.php
+++ b/tests/Unit/BugReportTemplateTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Regression test for #155: .github/ISSUE_TEMPLATE/bug.yml's example
+ * placeholders were stale — "Package Version" suggested 2.0.0 and
+ * "Laravel Version" suggested 9.0.0, even though the README's Requirements
+ * section and CHANGELOG.md show only Laravel 11.x/12.x are supported as of
+ * v2.0.0, and the package has since moved well past 2.0.0. A reporter
+ * skimming the placeholders could reasonably infer those old, unsupported
+ * versions were still current/in-scope examples.
+ */
+describe('.github/ISSUE_TEMPLATE/bug.yml', function () {
+    beforeEach(function () {
+        $this->template = file_get_contents(__DIR__.'/../../.github/ISSUE_TEMPLATE/bug.yml');
+    });
+
+    it('does not suggest the pre-v2.0.0 package version as an example', function () {
+        expect($this->template)->not->toMatch('/placeholder:\s*2\.0\.0/');
+    });
+
+    it('does not suggest the dropped Laravel 9.x as an example version', function () {
+        expect($this->template)->not->toMatch('/placeholder:\s*9\.0\.0/');
+    });
+
+    it('suggests a Laravel version placeholder within the currently supported 11.x/12.x range', function () {
+        preg_match('/label: Laravel Version.*?placeholder:\s*(\S+)/s', $this->template, $matches);
+
+        expect($matches[1] ?? null)->toMatch('/^1[12]\./');
+    });
+});


### PR DESCRIPTION
## What was broken

`.github/ISSUE_TEMPLATE/bug.yml`'s example placeholders were stale leftovers from an old release:

- "Package Version" suggested `2.0.0`
- "Laravel Version" suggested `9.0.0`

Per the README's Requirements section and `CHANGELOG.md`, only Laravel 11.x/12.x are supported as of v2.0.0, and the package's current release is well past `2.0.0` (`v3.1.2` per `CHANGELOG.md`). A reporter skimming the placeholder text could reasonably (if incorrectly) infer that `2.0.0` / Laravel `9.0.0` are still current/in-scope examples, leading to confusing bug reports against unsupported combinations, or reporters second-guessing whether their own correct, current version numbers "look right" next to the example.

## What changed

- Updated the "Package Version" placeholder from `2.0.0` to `3.1.2`.
- Updated the "Laravel Version" placeholder from `9.0.0` to `12.0.0` (within the currently supported 11.x/12.x range).
- Added `tests/Unit/BugReportTemplateTest.php`, a regression test that asserts the template no longer suggests the old `2.0.0` / `9.0.0` examples and that the Laravel version placeholder stays within the supported `11.x`/`12.x` range.

Fixes #155

## Testing

- `vendor/bin/pint --dirty` — no style issues
- `composer test` — full suite passes (253 tests, 634 assertions)